### PR TITLE
Proper module split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pkg
 .yardoc
 reports
 .allure
+doc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,2 @@
+allure-ruby-commons/lib/**/*.rb
+allure-cucumber/lib/**/*.rb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Allure ruby
 
-Ruby testing framework adaptors for generating allure compatible test reports
+[![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://rubydoc.info/github/allure-framework/allure-ruby/master)\
+Ruby testing framework adaptors for generating allure compatible test reports.
 
 ## allure-ruby-commons
 

--- a/allure-cucumber/README.md
+++ b/allure-cucumber/README.md
@@ -9,61 +9,68 @@ Add this line to your application's Gemfile:
 ```ruby
 gem 'allure-cucumber'
 ```
+
 And then execute:
+
 ```bash
-$ bundle
+  $ bundle
 ```
 
 Or install it yourself as:
+
 ```bash
-$ gem install allure-cucumber
+  $ gem install allure-cucumber
 ```
 
 ## Configuration
 
-By default, Allure json files are stored in `reports/allure-results`. To change this add the following in `features/support/env.rb` file:
+Common allure configuration is set via `Allure.configure` method. To change id, add the following in `features/support/env.rb` file:
 
 ```ruby
 Allure.configure do |c|
-   c.results_directory = "/output/dir"
+  c.results_directory = "/whatever/you/like"
+  c.logging_level = Logger::INFO
+  # these are used for creating links to bugs or test cases where {} is replaced with keys of relevant items
+  c.link_tms_pattern = "http://www.jira.com/browse/{}"
+  c.link_issue_pattern = "http://www.jira.com/browse/{}"
 end
 ```
 
 By default, allure-cucumber will analyze your cucumber tags looking for Test Management, Issue Management, and Severity hooks. Links to TMS and ISSUE and test severity will be displayed in the report. By default these prefixes are used:
 
-```ruby    
+```ruby
     DEFAULT_TMS_PREFIX      = 'TMS:'
     DEFAULT_ISSUE_PREFIX    = 'ISSUE:'
     DEFAULT_SEVERITY_PREFIX = 'SEVERITY:'
 ```
 
-Example: 
+Example:
+
 ```gherkin
   @SEVERITY:trivial @ISSUE:YZZ-100 @TMS:9901
   Scenario: Leave First Name Blank
     When I register an account without a first name
     Then exactly (1) [validation_error] should be visible
-```    
+```
 
 You can configure these prefixes as well as tms and issue tracker urls like this:
 
 ```ruby
-Allure.configure do |c|
-  c.link_tms_pattern = "http://www.hiptest.com/tms/{}"
-  c.link_issue_pattern = "http://www.jira.com/browse/{}"
+AllureCucumber.configure do |c|
   c.tms_prefix      = 'HIPTEST--'
   c.issue_prefix    = 'JIRA++'
   c.severity_prefix = 'URGENCY:'
 end
 ```
 
-Example: 
+Example:
+
 ```gherkin
   @URGENCY:critical @JIRA++YZZ-100 @HIPTEST--9901
   Scenario: Leave First Name Blank
     When I register an account without a first name
     Then exactly (1) [validation_error] should be visible
-```    
+```
 
 Additional special tags exists for setting status detail of test scenarios, allure will pick up following tags: `@flaky`, `@known` and `@muted`
 
@@ -89,4 +96,5 @@ Allure.add_link("Custom Url", "http://www.github.com")
 ```
 
 ## How to generate report
+
 This adaptor only generates json files containing information about tests. See [wiki section](https://docs.qameta.io/allure/#_reporting) on how to generate report.

--- a/allure-cucumber/README.md
+++ b/allure-cucumber/README.md
@@ -82,7 +82,7 @@ Put the following in your `features/support/env.rb` file:
 require 'allure-cucumber'
 ```
 
-Use `--format Allure::CucumberFormatter --out where/you-want-results` while running cucumber or add it to `cucumber.yml`
+Use `--format AllureCucumber::CucumberFormatter --out where/you-want-results` while running cucumber or add it to `cucumber.yml`
 
 You can also manually attach screenshots and links to test steps and test cases by interacting with allure lifecycle directly. For more info check out `allure-ruby-commons`
 

--- a/allure-cucumber/lib/allure-cucumber.rb
+++ b/allure-cucumber/lib/allure-cucumber.rb
@@ -6,6 +6,7 @@ require "allure-ruby-commons"
 require "allure_cucumber/formatter"
 require "allure_cucumber/config"
 
+# Main allure-cucumber module providing configuration methods
 module AllureCucumber
   class << self
     # Get allure cucumber configuration

--- a/allure-cucumber/lib/allure-cucumber.rb
+++ b/allure-cucumber/lib/allure-cucumber.rb
@@ -6,7 +6,7 @@ require "allure-ruby-commons"
 require "allure_cucumber/formatter"
 require "allure_cucumber/config"
 
-module Allure
+module AllureCucumber
   class << self
     # Get allure cucumber configuration
     # @return [Allure::CucumberConfig]

--- a/allure-cucumber/lib/allure_cucumber/ast_transformer.rb
+++ b/allure-cucumber/lib/allure_cucumber/ast_transformer.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# Cucumber::Core::Ast is removed in cucumber-core 4.0 version.
-# This will have to be updated accordingly, once stable version rolls out
-
-module Allure
+module AllureCucumber
+  # Cucumber::Core::Ast is removed in cucumber-core 4.0 version.
+  # This will have to be updated accordingly, once stable version rolls out
   module AstTransformer
     # Get scenario object
     # @param [Cucumber::Core::Test::Case] test_case
@@ -15,7 +14,7 @@ module Allure
     end
 
     # Get step object
-    # @param [Cucumber::Core::Test::Step] test_case
+    # @param [Cucumber::Core::Test::Step] test_step
     # @return [Cucumber::Core::Ast::Step]
     def step(test_step)
       test_step.source.detect { |it| it.is_a?(Cucumber::Core::Ast::Step) }

--- a/allure-cucumber/lib/allure_cucumber/config.rb
+++ b/allure-cucumber/lib/allure_cucumber/config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Allure
-  class CucumberConfig < Config
+module AllureCucumber
+  class CucumberConfig
     class << self
       DEFAULT_TMS_PREFIX = "TMS:"
       DEFAULT_ISSUE_PREFIX = "ISSUE:"

--- a/allure-cucumber/lib/allure_cucumber/config.rb
+++ b/allure-cucumber/lib/allure_cucumber/config.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 module AllureCucumber
+  # Allure cucumber configuration
   class CucumberConfig
     class << self
+      # @return [String] default tms tag prefix
       DEFAULT_TMS_PREFIX = "TMS:"
+      # @return [String] default issue tag prefix
       DEFAULT_ISSUE_PREFIX = "ISSUE:"
+      # @return [String] default severity tag prefix
       DEFAULT_SEVERITY_PREFIX = "SEVERITY:"
 
       attr_writer :tms_prefix, :issue_prefix, :severity_prefix

--- a/allure-cucumber/lib/allure_cucumber/cucumber_model.rb
+++ b/allure-cucumber/lib/allure_cucumber/cucumber_model.rb
@@ -8,7 +8,7 @@ require "csv"
 require_relative "ast_transformer"
 require_relative "tag_parser"
 
-module Allure
+module AllureCucumber
   # Support class for transforming cucumber test entities in to allure model entities
   class AllureCucumberModel
     extend AstTransformer
@@ -19,7 +19,7 @@ module Allure
       # @param [Cucumber::Core::Test::Case] test_case
       # @return [TestResult]
       def test_result(test_case)
-        TestResult.new(
+        Allure::TestResult.new(
           name: test_case.name,
           description: description(test_case),
           description_html: description(test_case),
@@ -36,7 +36,7 @@ module Allure
       # @param [Cucumber::Core::Test::Step] test_step
       # @return [StepResult]
       def step_result(test_step)
-        StepResult.new(
+        Allure::StepResult.new(
           name: "#{step(test_step).keyword}#{test_step.text}",
           attachments: [multiline_arg_attachment(test_step)].compact,
         )
@@ -47,7 +47,7 @@ module Allure
       # @return [StepResult]
       def fixture_result(test_step)
         location = test_step.location.to_s.split("/").last
-        FixtureResult.new(name: location)
+        Allure::FixtureResult.new(name: location)
       end
 
       # Get failure details
@@ -72,12 +72,12 @@ module Allure
       # @return [Array<Allure::Label>]
       def labels(test_case)
         labels = []
-        labels << ResultUtils.framework_label("cucumber")
-        labels << ResultUtils.feature_label(test_case.feature.name)
-        labels << ResultUtils.package_label(test_case.feature.name)
-        labels << ResultUtils.suite_label(test_case.feature.name)
-        labels << ResultUtils.story_label(test_case.name)
-        labels << ResultUtils.test_class_label(test_case.name)
+        labels << Allure::ResultUtils.framework_label("cucumber")
+        labels << Allure::ResultUtils.feature_label(test_case.feature.name)
+        labels << Allure::ResultUtils.package_label(test_case.feature.name)
+        labels << Allure::ResultUtils.suite_label(test_case.feature.name)
+        labels << Allure::ResultUtils.story_label(test_case.name)
+        labels << Allure::ResultUtils.test_class_label(test_case.name)
         unless test_case.tags.empty?
           labels.push(*tag_labels(test_case.tags))
           labels << severity(test_case.tags)
@@ -97,7 +97,7 @@ module Allure
       # @param [Cucumber::Core::Test::Case] test_case
       # @return [Array<Allure::Parameter>]
       def parameters(test_case)
-        example_row(test_case)&.values&.map { |value| Parameter.new("argument", value) }
+        example_row(test_case)&.values&.map { |value| Allure::Parameter.new("argument", value) }
       end
 
       # @param [Cucumber::Core::Test::Case] test_case
@@ -119,7 +119,7 @@ module Allure
       # @param [Cucumber::Core::Ast::DataTable] multiline_arg
       # @return [Allure::Attachment]
       def data_table_attachment(multiline_arg)
-        attachment = lifecycle.prepare_attachment("data-table", ContentType::CSV)
+        attachment = lifecycle.prepare_attachment("data-table", Allure::ContentType::CSV)
         csv = multiline_arg.raw.each_with_object([]) { |row, arr| arr.push(row.to_csv) }.join("")
         lifecycle.write_attachment(csv, attachment)
         attachment
@@ -128,7 +128,7 @@ module Allure
       # @param [String] multiline_arg
       # @return [String]
       def docstring_attachment(multiline_arg)
-        attachment = lifecycle.prepare_attachment("docstring", ContentType::TXT)
+        attachment = lifecycle.prepare_attachment("docstring", Allure::ContentType::TXT)
         lifecycle.write_attachment(multiline_arg.content, attachment)
         attachment
       end

--- a/allure-cucumber/lib/allure_cucumber/formatter.rb
+++ b/allure-cucumber/lib/allure_cucumber/formatter.rb
@@ -5,10 +5,12 @@ require_relative "cucumber_model"
 module AllureCucumber
   # Main formatter class. Translates cucumber event to allure lifecycle
   class CucumberFormatter
+    # @return [Hash] hook handler methods
     HOOK_HANDLERS = {
       "Before hook" => :start_prepare_fixture,
       "After hook" => :start_tear_down_fixture,
     }.freeze
+    # @return [Hash] allure statuses mapping
     ALLURE_STATUS = {
       failed: Allure::Status::FAILED,
       skipped: Allure::Status::SKIPPED,

--- a/allure-cucumber/lib/allure_cucumber/tag_parser.rb
+++ b/allure-cucumber/lib/allure_cucumber/tag_parser.rb
@@ -3,6 +3,7 @@
 require_relative "config"
 
 module AllureCucumber
+  # Cucumber tag parser helper methods
   module TagParser
     # @param [Cucumber::Core::Ast::Tag] tags
     # @return [Array<Allure::Label>]

--- a/allure-cucumber/lib/allure_cucumber/tag_parser.rb
+++ b/allure-cucumber/lib/allure_cucumber/tag_parser.rb
@@ -2,36 +2,36 @@
 
 require_relative "config"
 
-module Allure
+module AllureCucumber
   module TagParser
     # @param [Cucumber::Core::Ast::Tag] tags
     # @return [Array<Allure::Label>]
     def tag_labels(tags)
       tags
         .reject { |tag| reserved?(tag.name) }
-        .map { |tag| ResultUtils.tag_label(tag.name.delete_prefix("@")) }
+        .map { |tag| Allure::ResultUtils.tag_label(tag.name.delete_prefix("@")) }
     end
 
     # @param [Cucumber::Core::Ast::Tag] tags
     # @return [Array<Allure::Link>]
     def tms_links(tags)
-      return [] unless CucumberConfig.link_tms_pattern
+      return [] unless Allure::Config.link_tms_pattern
 
       tms_pattern = reserved_patterns[:tms]
       tags
         .select { |tag| tag.name.match?(tms_pattern) }
-        .map { |tag| tag.name.match(tms_pattern) { |match| ResultUtils.tms_link(match[:tms]) } }
+        .map { |tag| tag.name.match(tms_pattern) { |match| Allure::ResultUtils.tms_link(match[:tms]) } }
     end
 
     # @param [Cucumber::Core::Ast::Tag] tags
     # @return [Array<Allure::Link>]
     def issue_links(tags)
-      return [] unless CucumberConfig.link_issue_pattern
+      return [] unless Allure::Config.link_issue_pattern
 
       issue_pattern = reserved_patterns[:issue]
       tags
         .select { |tag| tag.name.match?(issue_pattern) }
-        .map { |tag| tag.name.match(issue_pattern) { |match| ResultUtils.issue_link(match[:issue]) } }
+        .map { |tag| tag.name.match(issue_pattern) { |match| Allure::ResultUtils.issue_link(match[:issue]) } }
     end
 
     # @param [Cucumber::Core::Ast::Tag] tags
@@ -42,7 +42,7 @@ module Allure
         .detect { |tag| tag.name.match?(severity_pattern) }&.name
         &.match(severity_pattern)&.[](:severity) || "normal"
 
-      ResultUtils.severity_label(severity)
+      Allure::ResultUtils.severity_label(severity)
     end
 
     # @param [Cucumber::Core::Ast::Tag] tags

--- a/allure-cucumber/spec/integration/full_report_spec.rb
+++ b/allure-cucumber/spec/integration/full_report_spec.rb
@@ -4,7 +4,7 @@ describe "allure-cucumber" do
   include_context "cucumber runner"
 
   let(:allure_cli) { Allure::Util.allure_cli }
-  let(:results_dir) { Allure::CucumberConfig.results_directory }
+  let(:results_dir) { Allure::Config.results_directory }
 
   before(:each) do
     FileUtils.remove_dir(results_dir) if File.exist?(results_dir)

--- a/allure-cucumber/spec/spec_helper.rb
+++ b/allure-cucumber/spec/spec_helper.rb
@@ -17,7 +17,7 @@ end
 RSpec.shared_context("cucumber runner") do
   def run_cucumber_cli(feature, *additional_args)
     configuration = Cucumber::Cli::Configuration.new.tap do |config|
-      args = [feature, "--format", "Allure::CucumberFormatter"]
+      args = [feature, "--format", "AllureCucumber::CucumberFormatter"]
       args.push(*additional_args)
       config.parse!(args)
     end

--- a/allure-ruby-commons/lib/allure_ruby_commons/allure_lifecycle.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/allure_lifecycle.rb
@@ -163,6 +163,8 @@ module Allure
       yield(@current_fixture)
     end
 
+    # Stop current test fixture
+    # @return [void]
     def stop_fixture
       return logger.error("Could not stop fixture, fixture is not started") unless @current_fixture
 

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -3,8 +3,11 @@
 require "logger"
 
 module Allure
+  # Allure configuration class
   class Config
+    # @return [String] default allure results directory
     DEFAULT_RESULTS_DIRECTORY = "reports/allure-results"
+    # @return [String] default loggin level
     DEFAULT_LOGGING_LEVEL = Logger::INFO
 
     class << self

--- a/allure-ruby-commons/lib/allure_ruby_commons/file_writer.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/file_writer.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 module Allure
+  # Allure result file writer
   class FileWriter
+    # @return [String] test result suffix
     TEST_RESULT_SUFFIX = "-result.json"
+    # @return [String] test result container suffix
     TEST_RESULT_CONTAINER_SUFFIX = "-container.json"
+    # @return [String] attachment file suffix
     ATTACHMENT_FILE_SUFFIX = "-attachment"
 
     # Write test result

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/attachment.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/attachment.rb
@@ -3,6 +3,7 @@
 require_relative "jsonable"
 
 module Allure
+  # Allure model attachment object
   class Attachment < JSONable
     # @param [String] name attachment name
     # @param [String] type attachment type, {Allure::ContentType}

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/content_type.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/content_type.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Allure
+  # Commonly used mime type definitions
   class ContentType
     TXT = "text/plain"
     XML = "application/xml"
@@ -14,6 +15,9 @@ module Allure
     WEBM = "video/webm"
     JPG = "image/jpeg"
 
+    # Get file extension from mime type
+    # @param [String] content_type mime type
+    # @return [String] file extension
     def self.to_extension(content_type)
       constants.detect { |const| const_get(const) == content_type }&.to_s&.downcase
     end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/executable_item.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/executable_item.rb
@@ -3,6 +3,7 @@
 require_relative "jsonable"
 
 module Allure
+  # Allure model executable item
   class ExecutableItem < JSONable
     # @param [Hash] options
     # @option options [String] :name

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/fixture_result.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/fixture_result.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Allure
+  # Allure model fixture result
   class FixtureResult < ExecutableItem; end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/jsonable.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/jsonable.rb
@@ -3,6 +3,7 @@
 require "json"
 
 module Allure
+  # General jsonable object implementation
   class JSONable
     def as_json(_options = {})
       instance_variables.each_with_object({}) do |var, map|

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/label.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/label.rb
@@ -3,6 +3,7 @@
 require_relative "jsonable"
 
 module Allure
+  # Allure model label object
   class Label < JSONable
     def initialize(name, value)
       @name = name

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/link.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/link.rb
@@ -3,6 +3,7 @@
 require_relative "jsonable"
 
 module Allure
+  # Allure model link object
   class Link < JSONable
     def initialize(type, name, url)
       @type = type

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -3,6 +3,7 @@
 require_relative "jsonable"
 
 module Allure
+  # Allure model parameter object
   class Parameter < JSONable
     def initialize(name, value)
       @name = name

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/stage.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/stage.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Allure
+  # Allure stages
   class Stage
     SCHEDULED = "scheduled"
     RUNNING = "running"

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/status.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/status.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Allure
+  # Allure model statuses
   class Status
     FAILED = :failed
     BROKEN = :broken

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/status_details.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/status_details.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Allure
+  # Allure model status detail object
   class StatusDetails < JSONable
     # @param [Boolean] known
     # @param [Boolean] muted

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/step_result.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/step_result.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Allure
+  # Allure model step result object
   class StepResult < ExecutableItem; end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Allure
+  # Allure model test result container
   class TestResult < ExecutableItem
     # @param [String] uuid
     # @param [String] history_id

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/test_result_container.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/test_result_container.rb
@@ -2,6 +2,7 @@
 
 require_relative "jsonable"
 module Allure
+  # Allure model step result container
   class TestResultContainer < JSONable
     def initialize(uuid: UUID.generate, name: "Unnamed")
       @uuid = uuid

--- a/allure-ruby-commons/lib/allure_ruby_commons/result_utils.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/result_utils.rb
@@ -3,6 +3,7 @@
 require "socket"
 
 module Allure
+  # Variouse helper methods
   module ResultUtils
     ISSUE_LINK_TYPE = "issue"
     TMS_LINK_TYPE = "tms"

--- a/allure-ruby-commons/lib/allure_ruby_commons/util.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/util.rb
@@ -5,8 +5,11 @@ require "zip"
 require "pathname"
 
 module Allure
+  # Utility for downloading allure commandline binary
   class Util
+    # @return [String] CLI version
     ALLURE_CLI_VERSION = "2.12.1"
+    # @return [String] CLI bin download url
     ALLURE_BIN_URL = "http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/"\
                       "#{ALLURE_CLI_VERSION}/allure-commandline-#{ALLURE_CLI_VERSION}.zip"
 

--- a/allure-ruby-commons/lib/allure_ruby_commons/util.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/util.rb
@@ -6,7 +6,7 @@ require "pathname"
 
 module Allure
   class Util
-    ALLURE_CLI_VERSION = "2.10.0"
+    ALLURE_CLI_VERSION = "2.12.1"
     ALLURE_BIN_URL = "http://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/"\
                       "#{ALLURE_CLI_VERSION}/allure-commandline-#{ALLURE_CLI_VERSION}.zip"
 


### PR DESCRIPTION
* Split allure-commons and allure-cucumber modules to allow proper documentation generation
* Overall improvement of yard docs
This is a braking change as it will require to configure common allure behaviour and allure cucumber behaviour separately