### PR TITLE
Fix commiter info of coveralls for initial pull_request creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: bundle exec rake test_with_coverage
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          CI: true
+          CI: "true"
           CI_NAME: github-ci
           CI_PULL_REQUEST: ${{ github.event.number }}
-          GIT_ID: ${{ github.event.after }}
+          CONTEXT: ${{ toJson(github) }}


### PR DESCRIPTION
github.event.after doesn't exist on first creation of pull request so commiter info is incorrect.