### PR TITLE
Use default values for anonymous groups instead of empty strings

### DIFF
--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -38,9 +38,10 @@ module AllureRspec
     # @param [RSpec::Core::Notifications::GroupNotification] example_group_notification
     # @return [void]
     def example_group_started(example_group_notification)
-      lifecycle.start_test_container(
-        Allure::TestResultContainer.new(name: example_group_notification.group.description),
-      )
+      description = example_group_notification.group.description.yield_self do |desc|
+        desc.empty? ? "Anonymous" : desc
+      end
+      lifecycle.start_test_container(Allure::TestResultContainer.new(name: description))
     end
 
     # Starts example

--- a/allure-rspec/lib/allure_rspec/rspec_model.rb
+++ b/allure-rspec/lib/allure_rspec/rspec_model.rb
@@ -84,10 +84,10 @@ module AllureRspec
     # @return [Array<Allure::Label>]
     def suite_labels(example_group)
       [].tap do |labels|
-        parents = example_group.parent_groups.map(&:description)
+        parents = example_group.parent_groups.map { |group| group.description.empty? ? "Anonymous" : group.description }
         labels << Allure::ResultUtils.suite_label(suite(parents))
-        labels << Allure::ResultUtils.parent_suite_label(parent_suite(parents))
-        labels << Allure::ResultUtils.sub_suite_label(sub_suites(parents))
+        labels << Allure::ResultUtils.parent_suite_label(parent_suite(parents)) if parent_suite(parents)
+        labels << Allure::ResultUtils.sub_suite_label(sub_suites(parents)) if sub_suites(parents)
       end
     end
 

--- a/allure-rspec/lib/allure_rspec/rspec_model.rb
+++ b/allure-rspec/lib/allure_rspec/rspec_model.rb
@@ -67,28 +67,30 @@ module AllureRspec
     # @param [RSpec::Core::Example] example
     # @return [Array<Allure::Label>]
     def labels(example)
-      [].tap do |labels|
-        labels << Allure::ResultUtils.framework_label("rspec")
-        labels << Allure::ResultUtils.feature_label(example.example_group.description)
-        labels << Allure::ResultUtils.package_label(Pathname.new(strip_relative(example.file_path)).parent.to_s)
-        labels << Allure::ResultUtils.story_label(example.description)
-        labels << Allure::ResultUtils.test_class_label(File.basename(example.file_path, ".rb"))
-        labels << severity(example.metadata)
-        labels.push(*tag_labels(example.metadata))
-        labels.push(*suite_labels(example.example_group))
-      end
+      labels = []
+      labels << Allure::ResultUtils.framework_label("rspec")
+      labels << Allure::ResultUtils.feature_label(example.example_group.description)
+      labels << Allure::ResultUtils.package_label(Pathname.new(strip_relative(example.file_path)).parent.to_s)
+      labels << Allure::ResultUtils.story_label(example.description)
+      labels << Allure::ResultUtils.test_class_label(File.basename(example.file_path, ".rb"))
+      labels << severity(example.metadata)
+      labels.push(*tag_labels(example.metadata))
+      labels.push(*suite_labels(example.example_group))
+
+      labels
     end
 
     # Add suite labels
     # @param [RSpec::Core::ExampleGroup] example_group
     # @return [Array<Allure::Label>]
     def suite_labels(example_group)
-      [].tap do |labels|
-        parents = example_group.parent_groups.map { |group| group.description.empty? ? "Anonymous" : group.description }
-        labels << Allure::ResultUtils.suite_label(suite(parents))
-        labels << Allure::ResultUtils.parent_suite_label(parent_suite(parents)) if parent_suite(parents)
-        labels << Allure::ResultUtils.sub_suite_label(sub_suites(parents)) if sub_suites(parents)
-      end
+      parents = example_group.parent_groups.map { |group| group.description.empty? ? "Anonymous" : group.description }
+      labels = []
+      labels << Allure::ResultUtils.suite_label(suite(parents))
+      labels << Allure::ResultUtils.parent_suite_label(parent_suite(parents)) if parent_suite(parents)
+      labels << Allure::ResultUtils.sub_suite_label(sub_suites(parents)) if sub_suites(parents)
+
+      labels
     end
 
     # @param [Array<String>] parents

--- a/allure-rspec/spec/integration/full_report_spec.rb
+++ b/allure-rspec/spec/integration/full_report_spec.rb
@@ -6,8 +6,8 @@ describe "allure rspec" do
   let(:results_dir) { Allure.configuration.results_directory }
 
   it "generates allure json results files", integration: true do
-    run_rspec(<<~SPEC)
-      describe "Suite" do
+    run_rspec(<<~RUBY)
+      describe do
         before(:each) do |e|
           e.step(name: "Before hook")
         end
@@ -20,7 +20,7 @@ describe "allure rspec" do
           e.step(name: "test body")
         end
       end
-    SPEC
+    RUBY
 
     container = File.new(Dir["#{test_tmp_dir}/#{results_dir}/*container.json"].first)
     result = File.new(Dir["#{test_tmp_dir}/#{results_dir}/*result.json"].first)
@@ -33,7 +33,7 @@ describe "allure rspec" do
     container_json = JSON.parse(File.read(container), symbolize_names: true)
     result_json = JSON.parse(File.read(result), symbolize_names: true)
     aggregate_failures "Json results should contain valid data" do
-      expect(container_json[:name]).to eq("Suite")
+      expect(container_json[:name]).to eq("Anonymous")
       expect(result_json[:name]).to eq("spec")
       expect(result_json[:description]).to eq("Location - #{test_tmp_dir}/spec/test_spec.rb:10")
       expect(result_json[:steps].size).to eq(3)


### PR DESCRIPTION
Fix issues when using context and describe blocks without description.
Fix issue with creating parent and sub suite labels without value.

Closes #127 