### PR TITLE
Add support for testplan.json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development do
 end
 
 group :test do
+  gem "climate_control", "~> 0.2.0"
   gem "rspec", "~> 3.10.0"
   gem "rubocop", "~> 0.93.1"
   gem "rubocop-performance", "~> 1.8.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,8 +162,8 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
-    sys-uname (1.2.1)
-      ffi (>= 1.0.0)
+    sys-uname (1.2.2)
+      ffi (~> 1.1)
     systemu (2.6.5)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -176,7 +176,7 @@ GEM
     uuid (2.3.9)
       macaddr (~> 1.0)
     yard (0.9.25)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
     backport (1.1.2)
     benchmark (0.1.0)
     builder (3.2.4)
+    climate_control (0.2.0)
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.7)
@@ -185,6 +186,7 @@ DEPENDENCIES
   allure-rspec!
   allure-ruby-commons!
   bundler (~> 2.1.2)
+  climate_control (~> 0.2.0)
   colorize (~> 0.8.1)
   lefthook (~> 0.7.2)
   pry (~> 0.13.1)

--- a/allure-cucumber/lib/allure_cucumber/formatter.rb
+++ b/allure-cucumber/lib/allure_cucumber/formatter.rb
@@ -21,8 +21,14 @@ module AllureCucumber
 
     # @param [Cucumber::Configuration] config
     def initialize(config)
-      Allure.configure do |c|
-        c.results_directory = config.out_stream if config.out_stream.is_a?(String)
+      Allure.configure do |allure_config|
+        allure_config.results_directory = config.out_stream if config.out_stream.is_a?(String)
+
+        ids = allure_config.test_ids
+        names = allure_config.test_names
+
+        config.tag_expressions.push(*ids.map { |id| "@ALLURE_ID-#{id}" }) if ids
+        config.name_regexps.push(*names.map { |name| /#{name}/ }) if names
       end
 
       @cucumber_model = AllureCucumberModel.new(config)

--- a/allure-cucumber/lib/allure_cucumber/formatter.rb
+++ b/allure-cucumber/lib/allure_cucumber/formatter.rb
@@ -24,10 +24,7 @@ module AllureCucumber
       Allure.configure do |allure_config|
         allure_config.results_directory = config.out_stream if config.out_stream.is_a?(String)
 
-        ids = allure_config.test_ids
         names = allure_config.test_names
-
-        config.tag_expressions.push(*ids.map { |id| "@ALLURE_ID-#{id}" }) if ids
         config.name_regexps.push(*names.map { |name| /#{name}/ }) if names
       end
 

--- a/allure-cucumber/lib/allure_cucumber/models/cucumber_model.rb
+++ b/allure-cucumber/lib/allure_cucumber/models/cucumber_model.rb
@@ -29,7 +29,7 @@ module AllureCucumber
         description: scenario.description,
         description_html: scenario.description,
         history_id: scenario.id,
-        full_name: "#{scenario.feature_name}: #{scenario.name}",
+        full_name: scenario.name,
         labels: labels(scenario),
         links: links(scenario),
         parameters: parameters(scenario),

--- a/allure-cucumber/spec/unit/formatter_test_case_started_spec.rb
+++ b/allure-cucumber/spec/unit/formatter_test_case_started_spec.rb
@@ -35,7 +35,7 @@ describe "on_test_case_started" do
       aggregate_failures "Should have correct args" do
         expect(arg.name).to eq(scenario)
         expect(arg.description).to eq("Simple scenario description")
-        expect(arg.full_name).to eq("#{feature}: #{scenario}")
+        expect(arg.full_name).to eq(scenario)
         expect(arg.links).to be_empty
         expect(arg.parameters).to be_empty
         expect(arg.history_id).to eq(

--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -33,7 +33,7 @@ module AllureRspec
         names = allure_config.test_names
 
         config.filter_run_when_matching(*ids.map { |id| { allure_id: id } }) if ids
-        config.before(:example) { |ex| skip("Set by allure!") unless names.include?(ex.full_description) } if names
+        config.full_description = names if names
       end
     end
 

--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -28,9 +28,9 @@ module AllureRspec
     end
 
     RSpec.configure do |config|
-      Allure.configuration.tap do |allure|
-        ids = allure.test_ids
-        names = allure.test_names
+      Allure.configure do |allure_config|
+        ids = allure_config.test_ids
+        names = allure_config.test_names
 
         config.filter_run_when_matching(*ids.map { |id| { allure_id: id } }) if ids
         config.before(:example) { |ex| skip("Set by allure!") unless names.include?(ex.full_description) } if names

--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -27,6 +27,14 @@ module AllureRspec
       end
     end
 
+    RSpec.configure do |config|
+      ids = AllureRspec.configuration.test_ids
+      names = AllureRspec.configuration.test_names
+
+      config.filter_run_when_matching(*ids.map { |id| { allure_id: id } }) if ids
+      config.prepend_before { |ex| ex.skip("Skip set by allure") if names.include?(ex.full_description) } if name
+    end
+
     # Start test run
     # @param [RSpec::Core::Notifications::StartNotification] _start_notification
     # @return [void]

--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -28,11 +28,13 @@ module AllureRspec
     end
 
     RSpec.configure do |config|
-      ids = AllureRspec.configuration.test_ids
-      names = AllureRspec.configuration.test_names
+      Allure.configuration.tap do |allure|
+        ids = allure.test_ids
+        names = allure.test_names
 
-      config.filter_run_when_matching(*ids.map { |id| { allure_id: id } }) if ids
-      config.prepend_before { |ex| ex.skip("Skip set by allure") if names.include?(ex.full_description) } if name
+        config.filter_run_when_matching(*ids.map { |id| { allure_id: id } }) if ids
+        config.before(:example) { |ex| skip("Set by allure!") unless names.include?(ex.full_description) } if names
+      end
     end
 
     # Start test run

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -10,6 +10,8 @@ module Allure
 
     # @return [Array<String>] valid log levels
     LOGLEVELS = %w[DEBUG INFO WARN ERROR FATAL UNKNOWN].freeze
+    # @return [String] test plan file name
+    TEST_PLAN_JSON = "testplan.json"
 
     def initialize
       @results_directory = "reports/allure-results"
@@ -17,5 +19,18 @@ module Allure
     end
 
     attr_accessor :results_directory, :logging_level, :link_tms_pattern, :link_issue_pattern, :clean_results_directory
+
+    # Tests to execute from allure testplan.json
+    #
+    # @return [Array<Hash>]
+    def tests
+      ENV.fetch("ALLURE_TESTPLAN_PATH").yield_self do |path|
+        break unless path && File.exist?("#{path}/#{TEST_PLAN_JSON}")
+
+        Oj.load_file("#{path}/#{TEST_PLAN_JSON}", symbol_keys: true).fetch(:tests)
+      end
+    rescue Oj::ParseError
+      nil
+    end
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -20,6 +20,22 @@ module Allure
 
     attr_accessor :results_directory, :logging_level, :link_tms_pattern, :link_issue_pattern, :clean_results_directory
 
+    # Allure id's of executable tests
+    #
+    # @return [Array]
+    def test_ids
+      @test_ids ||= tests&.map { |test| test[:id] }
+    end
+
+    # Test names of executable tests
+    #
+    # @return [Array]
+    def test_names
+      @test_names ||= tests&.map { |test| test[:selector] }
+    end
+
+    private
+
     # Tests to execute from allure testplan.json
     #
     # @return [Array<Hash>]

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -24,13 +24,20 @@ module Allure
     #
     # @return [Array<Hash>]
     def tests
-      ENV.fetch("ALLURE_TESTPLAN_PATH").yield_self do |path|
-        break unless path && File.exist?("#{path}/#{TEST_PLAN_JSON}")
+      return unless test_plan
 
-        Oj.load_file("#{path}/#{TEST_PLAN_JSON}", symbol_keys: true).fetch(:tests)
-      end
+      Oj.load_file(test_plan, symbol_keys: true).fetch(:tests)
     rescue Oj::ParseError
       nil
+    end
+
+    private
+
+    def test_plan
+      path = ENV.fetch("ALLURE_TESTPLAN_PATH")
+      return unless path && File.exist?("#{path}/#{TEST_PLAN_JSON}")
+
+      "#{path}/#{TEST_PLAN_JSON}"
     end
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -24,10 +24,11 @@ module Allure
     #
     # @return [Array<Hash>]
     def tests
-      path = ENV.fetch("ALLURE_TESTPLAN_PATH")
-      return unless path && File.exist?("#{path}/#{TEST_PLAN_JSON}")
+      @tests ||= begin
+        return unless ENV["ALLURE_TESTPLAN_PATH"]
 
-      Oj.load_file("#{path}/#{TEST_PLAN_JSON}", symbol_keys: true).fetch(:tests)
+        Oj.load_file("#{ENV['ALLURE_TESTPLAN_PATH']}/#{TEST_PLAN_JSON}", symbol_keys: true)&.fetch(:tests)
+      end
     rescue Oj::ParseError
       nil
     end

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -24,20 +24,12 @@ module Allure
     #
     # @return [Array<Hash>]
     def tests
-      return unless test_plan
-
-      Oj.load_file(test_plan, symbol_keys: true).fetch(:tests)
-    rescue Oj::ParseError
-      nil
-    end
-
-    private
-
-    def test_plan
       path = ENV.fetch("ALLURE_TESTPLAN_PATH")
       return unless path && File.exist?("#{path}/#{TEST_PLAN_JSON}")
 
-      "#{path}/#{TEST_PLAN_JSON}"
+      Oj.load_file("#{path}/#{TEST_PLAN_JSON}", symbol_keys: true).fetch(:tests)
+    rescue Oj::ParseError
+      nil
     end
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -10,15 +10,17 @@ module Allure
 
     # @return [Array<String>] valid log levels
     LOGLEVELS = %w[DEBUG INFO WARN ERROR FATAL UNKNOWN].freeze
+    # @return [String] test plan path env var name
+    TESTPLAN_PATH = "ALLURE_TESTPLAN_PATH"
     # @return [String] test plan file name
-    TEST_PLAN_JSON = "testplan.json"
+    TESTPLAN_JSON = "testplan.json"
+
+    attr_accessor :results_directory, :logging_level, :link_tms_pattern, :link_issue_pattern, :clean_results_directory
 
     def initialize
       @results_directory = "reports/allure-results"
       @logging_level = LOGLEVELS.index(ENV.fetch("ALLURE_LOG_LEVEL", "INFO")) || Logger::INFO
     end
-
-    attr_accessor :results_directory, :logging_level, :link_tms_pattern, :link_issue_pattern, :clean_results_directory
 
     # Allure id's of executable tests
     #
@@ -41,9 +43,9 @@ module Allure
     # @return [Array<Hash>]
     def tests
       @tests ||= begin
-        return unless ENV["ALLURE_TESTPLAN_PATH"]
+        return unless ENV[TESTPLAN_PATH]
 
-        Oj.load_file("#{ENV['ALLURE_TESTPLAN_PATH']}/#{TEST_PLAN_JSON}", symbol_keys: true)&.fetch(:tests)
+        Oj.load_file("#{ENV[TESTPLAN_PATH]}/#{TESTPLAN_JSON}", symbol_keys: true)&.fetch(:tests)
       end
     rescue Oj::ParseError
       nil

--- a/allure-ruby-commons/spec/fixtures/test_plan/correct/testplan.json
+++ b/allure-ruby-commons/spec/fixtures/test_plan/correct/testplan.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "tests": [
+    {
+      "id": "test case id, aka allure id",
+      "selector": "some unique id or selector that can be used to run particular test case"
+    }
+  ]
+}

--- a/allure-ruby-commons/spec/fixtures/test_plan/malformed/testplan.json
+++ b/allure-ruby-commons/spec/fixtures/test_plan/malformed/testplan.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0"
+  "tests": [
+    {
+      "id": "test case id, aka allure id",
+      "selector": "some unique id or selector that can be used to run particular test case"
+    }
+  ]
+}

--- a/allure-ruby-commons/spec/spec_helper.rb
+++ b/allure-ruby-commons/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "simplecov"
 require "rspec"
+require "climate_control"
 require "allure-ruby-commons"
 require "pry"
 

--- a/allure-ruby-commons/spec/spec_helper.rb
+++ b/allure-ruby-commons/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "simplecov"
 require "rspec"
 require "allure-ruby-commons"
+require "pry"
 
 SimpleCov.command_name("allure-ruby-commons")
 

--- a/allure-ruby-commons/spec/unit/config_spec.rb
+++ b/allure-ruby-commons/spec/unit/config_spec.rb
@@ -10,9 +10,11 @@ describe Allure::Config do
     ]
   end
 
-  before { allow(ENV).to receive(:fetch).with("ALLURE_TESTPLAN_PATH") { path } }
+  around do |example|
+    ClimateControl.modify(ALLURE_TESTPLAN_PATH: path) { example.run }
+  end
 
-  subject { described_class.instance }
+  subject { Class.new(described_class).instance }
 
   context "handles" do
     let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan/correct" }

--- a/allure-ruby-commons/spec/unit/config_spec.rb
+++ b/allure-ruby-commons/spec/unit/config_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe Allure::Config do
+  let(:tests) do
+    [
+      {
+        id: "test case id, aka allure id",
+        selector: "some unique id or selector that can be used to run particular test case"
+      }
+    ]
+  end
+
+  before { allow(ENV).to receive(:fetch).with("ALLURE_TESTPLAN_PATH") { path } }
+
+  subject { described_class.instance }
+
+  context "handles" do
+    let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan/correct" }
+
+    it "correct testplan.json" do
+      expect(subject.tests).to eq(tests)
+    end
+  end
+
+  context "handles" do
+    let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan/malformed" }
+
+    it "malformed testplan.json" do
+      expect(subject.tests).to eq(nil)
+    end
+  end
+
+  context "handles" do
+    let(:path) { nil }
+
+    it "missing testplan.json" do
+      expect(subject.tests).to eq(nil)
+    end
+  end
+end

--- a/allure-ruby-commons/spec/unit/config_spec.rb
+++ b/allure-ruby-commons/spec/unit/config_spec.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
 describe Allure::Config do
-  let(:tests) do
-    [
-      {
-        id: "test case id, aka allure id",
-        selector: "some unique id or selector that can be used to run particular test case"
-      }
-    ]
-  end
+  let(:test_ids) { ["test case id, aka allure id"] }
+  let(:test_names) { ["some unique id or selector that can be used to run particular test case"] }
 
   around do |example|
     ClimateControl.modify(ALLURE_TESTPLAN_PATH: path) { example.run }
@@ -20,7 +14,10 @@ describe Allure::Config do
     let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan/correct" }
 
     it "correct testplan.json" do
-      expect(subject.tests).to eq(tests)
+      aggregate_failures do
+        expect(subject.test_ids).to eq(test_ids)
+        expect(subject.test_names).to eq(test_names)
+      end
     end
   end
 
@@ -28,7 +25,10 @@ describe Allure::Config do
     let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan/malformed" }
 
     it "malformed testplan.json" do
-      expect(subject.tests).to eq(nil)
+      aggregate_failures do
+        expect(subject.test_ids).to eq(nil)
+        expect(subject.test_names).to eq(nil)
+      end
     end
   end
 
@@ -36,7 +36,10 @@ describe Allure::Config do
     let(:path) { nil }
 
     it "missing testplan.json" do
-      expect(subject.tests).to eq(nil)
+      aggregate_failures do
+        expect(subject.test_ids).to eq(nil)
+        expect(subject.test_names).to eq(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
Adds support for testplan.json for allure-rspec

* Uses id field as `allure_id` tag in rspec tests by passing tags to [filter_run_when_matching](https://rubydoc.info/github/rspec/rspec-core/RSpec/Core/Configuration#filter_run_when_matching-instance_method) method
* Filters out specs by full name

Note that if allure id is used, it will filter out all tests that do not match it, which basically means also every test that isn't marked with `allure_id` tag (will pass tests to filter by name if none specs match)

Adds support for testplan.json for allure-cucumber

* Uses test name to apply as regex for scenario name

Not implemented filter by tags as it doesn't look like it's possible to implement tag expression similar to rspec as cucumber doesn't run anything if not scenarios match.

Closes #159 