### PR TITLE
feat: add support for rspec tags

### DIFF
--- a/allure-rspec/lib/allure_rspec/tag_parser.rb
+++ b/allure-rspec/lib/allure_rspec/tag_parser.rb
@@ -7,9 +7,9 @@ module AllureRspec
     # @param [Hash] metadata
     # @return [Array<Allure::Label>]
     def tag_labels(metadata)
-      return [] unless metadata.keys.any? { |k| allure?(k) }
-
-      metadata.select { |k| allure?(k) }.values.map { |v| Allure::ResultUtils.tag_label(v) }
+      metadata.reject { |k| RSPEC_IGNORED_METADATA.include?(k) }.map do |k, v|
+        allure?(k) ? Allure::ResultUtils.tag_label(v) : Allure::ResultUtils.tag_label(k.to_s)
+      end
     end
 
     # Get tms links
@@ -45,6 +45,28 @@ module AllureRspec
     end
 
     private
+
+    RSPEC_IGNORED_METADATA = %i[
+      absolute_file_path
+      block
+      described_class
+      description
+      description_args
+      example_group
+      execution_result
+      file_path
+      full_description
+      last_run_status
+      line_number
+      location
+      rerun_file_path
+      retry
+      retry_attempts
+      retry_exceptions
+      scoped_id
+      shared_group_inclusion_backtrace
+      type
+    ].freeze
 
     # @param [Hash] metadata
     # @param [Symbol] type

--- a/allure-rspec/spec/unit/formatter_example_started_spec.rb
+++ b/allure-rspec/spec/unit/formatter_example_started_spec.rb
@@ -20,7 +20,7 @@ describe "example_started" do
           e.step(name: "After hook")
         end
 
-        it "#{spec}", allure: "some_label" do |e|
+        it "#{spec}", :rspec_tag_1, rspec_tag_2: true, allure: "some_label" do |e|
           e.step(name: "test body")
         end
       end
@@ -40,7 +40,9 @@ describe "example_started" do
           result_utils.framework_label("rspec"),
           result_utils.package_label("#{test_tmp_dir}/spec"),
           result_utils.test_class_label("test_spec"),
-          result_utils.tag_label("some_label")
+          result_utils.tag_label("some_label"),
+          result_utils.tag_label("rspec_tag_1"),
+          result_utils.tag_label("rspec_tag_2")
         )
       end
     end


### PR DESCRIPTION
The goal of this PR is to automatically report Rspec tags and support backward compatibility with existing labels `allure_`.