### PR TITLE
Avoid test execution failure while using Afterstep hooks 

### DIFF
--- a/allure-cucumber/lib/allure_cucumber/formatter.rb
+++ b/allure-cucumber/lib/allure_cucumber/formatter.rb
@@ -111,6 +111,8 @@ module AllureCucumber
     # @param [Cucumber::Core::Test::HookStep] hook_step
     # @return [void]
     def handle_hook_started(hook_step)
+      return unless HOOK_HANDLERS.key?(hook_step.text)
+
       lifecycle.public_send(HOOK_HANDLERS[hook_step.text], cucumber_model.fixture_result(hook_step))
     end
   end


### PR DESCRIPTION
Avoid execution error while using Afterstep hooks. The current implementation of the formatter does not include Afterstep hook behaviour, causing unexpected crashes while cucumber executes this step.

As per cucumber docs (https://cucumber.io/docs/cucumber/api/#hooks): 
`AfterStep
AfterStep do |scenario|
end
` 

This pull request is a workaround, it would be great to implement a solution that handles the Afterstep hook properly.


