### PR TITLE
Remove lifecycle copy in thread variable for rspec reporter

### DIFF
--- a/allure-cucumber/lib/allure_cucumber/config.rb
+++ b/allure-cucumber/lib/allure_cucumber/config.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "singleton"
-require "forwardable"
 
 module AllureCucumber
   # Allure cucumber configuration

--- a/allure-cucumber/lib/allure_cucumber/formatter.rb
+++ b/allure-cucumber/lib/allure_cucumber/formatter.rb
@@ -24,7 +24,7 @@ module AllureCucumber
       Allure.lifecycle = Allure::AllureLifecycle.new(AllureCucumber.configuration)
       AllureCucumber.configuration.results_directory = config.out_stream if config.out_stream.is_a?(String)
 
-      @cucumber_model ||= AllureCucumberModel.new(config, lifecycle.config)
+      @cucumber_model ||= AllureCucumberModel.new(config, AllureCucumber.configuration)
 
       names = Allure::TestPlan.test_names
       config.name_regexps.push(*names.map { |name| /#{name}/ }) if names

--- a/allure-cucumber/lib/allure_cucumber/formatter.rb
+++ b/allure-cucumber/lib/allure_cucumber/formatter.rb
@@ -5,6 +5,8 @@ require "cucumber/core"
 module AllureCucumber
   # Main formatter class. Translates cucumber event to allure lifecycle
   class CucumberFormatter
+    extend Forwardable
+
     # @return [Hash] hook handler methods
     HOOK_HANDLERS = {
       "Before hook" => :start_prepare_fixture,
@@ -19,8 +21,8 @@ module AllureCucumber
 
     # @param [Cucumber::Configuration] config
     def initialize(config)
-      @lifecycle = (Allure.lifecycle = Allure::AllureLifecycle.new(AllureCucumber.configuration))
-      @lifecycle.config.results_directory = config.out_stream if config.out_stream.is_a?(String)
+      Allure.lifecycle = Allure::AllureLifecycle.new(AllureCucumber.configuration)
+      AllureCucumber.configuration.results_directory = config.out_stream if config.out_stream.is_a?(String)
 
       @cucumber_model ||= AllureCucumberModel.new(config, lifecycle.config)
 
@@ -87,7 +89,9 @@ module AllureCucumber
 
     private
 
-    attr_reader :cucumber_model, :lifecycle
+    def_delegator :Allure, :lifecycle
+
+    attr_reader :cucumber_model
 
     # Is hook fixture like Before, After or Step as AfterStep
     # @param [String] text

--- a/allure-cucumber/spec/spec_helper.rb
+++ b/allure-cucumber/spec/spec_helper.rb
@@ -34,10 +34,9 @@ RSpec.shared_context("allure mock") do
 end
 
 RSpec.shared_context("cucumber runner") do
-  let(:test_tmp_dir) { |e| "tmp/#{e.full_description.tr(' ', '_')}" }
-  let(:cucumber) { CucumberHelper.new(test_tmp_dir) }
+  let!(:test_tmp_dir) { |e| "tmp/#{e.full_description.tr(' ', '_')}" }
 
   def run_cucumber_cli(feature)
-    cucumber.execute(feature)
+    Thread.new { CucumberHelper.new(test_tmp_dir).execute(feature) }.join
   end
 end

--- a/allure-rspec/lib/allure_rspec/config.rb
+++ b/allure-rspec/lib/allure_rspec/config.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "forwardable"
 require "singleton"
 
 module AllureRspec

--- a/allure-rspec/spec/spec_helper.rb
+++ b/allure-rspec/spec/spec_helper.rb
@@ -34,8 +34,7 @@ RSpec.shared_context("allure mock") do
 end
 
 RSpec.shared_context("rspec runner") do
-  let(:test_tmp_dir) { |e| "tmp/#{e.full_description.tr(' ', '_')}" }
-  let(:rspec_runner) { RspecRunner.new(test_tmp_dir) }
+  let!(:test_tmp_dir) { |e| "tmp/#{e.full_description.tr(' ', '_')}" }
 
   before do
     configuration = RSpec::Core::Configuration.new
@@ -46,6 +45,6 @@ RSpec.shared_context("rspec runner") do
   end
 
   def run_rspec(spec)
-    rspec_runner.run(spec)
+    Thread.new { RspecRunner.new(test_tmp_dir).run(spec) }.join
   end
 end

--- a/allure-ruby-commons/spec/spec_helper.rb
+++ b/allure-ruby-commons/spec/spec_helper.rb
@@ -20,9 +20,24 @@ RSpec.configure do |config|
   end
 end
 
-RSpec.shared_context("lifecycle") do
-  let(:config) { Allure::Config.send(:new).tap { |conf| conf.results_directory = "spec/allure-results" } }
+RSpec.shared_context("lifecycle mocks") do
   let(:lifecycle) { Allure::AllureLifecycle.new(config) }
+  let(:config) { Allure::Config.send(:new).tap { |conf| conf.results_directory = "spec/allure-results" } }
+
+  let(:file_writer) do
+    instance_double(
+      "FileWriter",
+      write_attachment: nil,
+      write_categories: nil,
+      write_environment: nil,
+      write_test_result: nil,
+      write_test_result_container: nil
+    )
+  end
+
+  before do
+    allow(Allure::FileWriter).to receive(:new).and_return(file_writer)
+  end
 
   def start_test_container(name)
     lifecycle.start_test_container(Allure::TestResultContainer.new(name: name))
@@ -46,14 +61,6 @@ RSpec.shared_context("lifecycle") do
 
   def start_test_step(**options)
     lifecycle.start_test_step(Allure::StepResult.new(**options))
-  end
-end
-
-RSpec.shared_context("lifecycle mocks") do
-  let(:file_writer) { double("FileWriter") }
-
-  before do
-    allow(Allure::FileWriter).to receive(:new).and_return(file_writer)
   end
 end
 

--- a/allure-ruby-commons/spec/unit/attachment_spec.rb
+++ b/allure-ruby-commons/spec/unit/attachment_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe "Lifecycle:Attachments" do
-  include_context "lifecycle"
   include_context "lifecycle mocks"
 
   let(:attach_opts) do
@@ -18,8 +17,6 @@ describe "Lifecycle:Attachments" do
   end
 
   it "adds attachment to fixture" do
-    expect(file_writer).to receive(:write_attachment).with("string attachment", duck_type(:name, :source, :type))
-
     fixture = lifecycle.start_prepare_fixture(Allure::FixtureResult.new(name: "Prepare fixture"))
     lifecycle.add_attachment(**attach_opts)
     attachment = fixture.attachments.last
@@ -27,12 +24,14 @@ describe "Lifecycle:Attachments" do
     aggregate_failures "Attachment should be added" do
       expect(attachment.name).to eq("Test Attachment")
       expect(attachment.type).to eq(Allure::ContentType::TXT)
+      expect(file_writer).to have_received(:write_attachment).with(
+        "string attachment",
+        duck_type(:name, :source, :type)
+      )
     end
   end
 
   it "adds attachment to step" do
-    expect(file_writer).to receive(:write_attachment).with("string attachment", duck_type(:name, :source, :type))
-
     test_step = start_test_step(name: "Step name", descrption: "step description")
     lifecycle.add_attachment(**attach_opts)
     attachment = test_step.attachments.last
@@ -40,24 +39,28 @@ describe "Lifecycle:Attachments" do
     aggregate_failures "Attachment should be added" do
       expect(attachment.name).to eq("Test Attachment")
       expect(attachment.type).to eq(Allure::ContentType::TXT)
+      expect(file_writer).to have_received(:write_attachment).with(
+        "string attachment",
+        duck_type(:name, :source, :type)
+      )
     end
   end
 
   it "adds attachment to test" do
-    expect(file_writer).to receive(:write_attachment).with("string attachment", duck_type(:name, :source, :type))
-
     lifecycle.add_attachment(**attach_opts)
     attachment = @test_case.attachments.last
 
     aggregate_failures "Attachment should be added" do
       expect(attachment.name).to eq("Test Attachment")
       expect(attachment.type).to eq(Allure::ContentType::TXT)
+      expect(file_writer).to have_received(:write_attachment).with(
+        "string attachment",
+        duck_type(:name, :source, :type)
+      )
     end
   end
 
   it "adds file attachment to test" do
-    expect(file_writer).to receive(:write_attachment).with(kind_of(File), duck_type(:name, :source, :type))
-
     lifecycle.add_attachment(
       name: "Test xlsx attachment",
       source: File.new(File.join(Dir.pwd, "spec", "fixtures", "blank.xlsx")),
@@ -69,12 +72,11 @@ describe "Lifecycle:Attachments" do
       expect(attachment.name).to eq("Test xlsx attachment")
       expect(attachment.type).to eq("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
       expect(attachment.source).to include(".xlsx")
+      expect(file_writer).to have_received(:write_attachment).with(kind_of(File), duck_type(:name, :source, :type))
     end
   end
 
   it "adds attachment to test explicitly" do
-    expect(file_writer).to receive(:write_attachment).with("string attachment", duck_type(:name, :source, :type))
-
     test_step = start_test_step(name: "Step name", descrption: "step description")
     lifecycle.add_attachment(**attach_opts, test_case: true)
     attachment = @test_case.attachments.last
@@ -83,21 +85,10 @@ describe "Lifecycle:Attachments" do
       expect(attachment.name).to eq("Test Attachment")
       expect(attachment.type).to eq(Allure::ContentType::TXT)
       expect(test_step.attachments).to be_empty
+      expect(file_writer).to have_received(:write_attachment).with(
+        "string attachment",
+        duck_type(:name, :source, :type)
+      )
     end
-  end
-
-  it "logs no running test case error" do
-    allow(file_writer).to receive(:write_test_result)
-
-    lifecycle.stop_test_case
-    lifecycle.add_attachment(**attach_opts)
-  end
-
-  it "logs incorrect mime type error" do
-    lifecycle.add_attachment(
-      name: "Test Attachment",
-      source: "string attachment",
-      type: "nonsence"
-    )
   end
 end

--- a/allure-ruby-commons/spec/unit/test_fixture_spec.rb
+++ b/allure-ruby-commons/spec/unit/test_fixture_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe "AllureLifecycle::Fixtures" do
-  include_context "lifecycle"
   include_context "lifecycle mocks"
 
   context "without exceptions" do

--- a/allure-ruby-commons/spec/unit/test_result_container_spec.rb
+++ b/allure-ruby-commons/spec/unit/test_result_container_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe "AllureLifecycle::TestResultContainer" do
-  include_context "lifecycle"
   include_context "lifecycle mocks"
 
   before do
@@ -19,24 +18,11 @@ describe "AllureLifecycle::TestResultContainer" do
   end
 
   it "stops test result container" do
-    allow(file_writer).to receive(:write_test_result_container)
     lifecycle.stop_test_container
 
-    expect(@result_container.stop).to be_a(Numeric)
-  end
-
-  it "calls file writer on stop" do
-    expect(file_writer).to receive(:write_test_result_container).with(@result_container)
-
-    lifecycle.stop_test_container
-  end
-
-  it "logs error when stopping or updating test result container" do
-    allow(file_writer).to receive(:write_test_result_container)
-
-    lifecycle.stop_test_container
-
-    lifecycle.update_test_container { |c| c.description = "Test" }
-    lifecycle.stop_test_container
+    aggregate_failures do
+      expect(@result_container.stop).to be_a(Numeric)
+      expect(file_writer).to have_received(:write_test_result_container).with(@result_container)
+    end
   end
 end

--- a/allure-ruby-commons/spec/unit/test_result_spec.rb
+++ b/allure-ruby-commons/spec/unit/test_result_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe "AllureLifecycle::TestCaseResult" do
-  include_context "lifecycle"
   include_context "lifecycle mocks"
 
   context "without exceptions" do
@@ -25,8 +24,6 @@ describe "AllureLifecycle::TestCaseResult" do
     end
 
     it "stops test" do
-      allow(file_writer).to receive(:write_test_result)
-
       lifecycle.stop_test_case
 
       aggregate_failures "Should update parameters" do
@@ -36,9 +33,9 @@ describe "AllureLifecycle::TestCaseResult" do
     end
 
     it "calls file writer on stop" do
-      expect(file_writer).to receive(:write_test_result).with(@test_case)
-
       lifecycle.stop_test_case
+
+      expect(file_writer).to have_received(:write_test_result).with(@test_case)
     end
 
     it "adds default labels" do

--- a/allure-ruby-commons/spec/unit/test_step_spec.rb
+++ b/allure-ruby-commons/spec/unit/test_step_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe "AllureLifecycle::TestStepResult" do
-  include_context "lifecycle"
   include_context "lifecycle mocks"
 
   context "without exceptions" do
@@ -9,8 +8,6 @@ describe "AllureLifecycle::TestStepResult" do
       @result_container = start_test_container("Test Container")
       @test_case = start_test_case(name: "Test case", full_name: "Full name")
       @test_step = start_test_step(name: "Step name", descrption: "step description")
-
-      allow(Allure::FileWriter).to receive(:new).and_return(file_writer)
     end
 
     it "starts test step" do
@@ -65,7 +62,7 @@ describe "AllureLifecycle::TestStepResult" do
       lifecycle.stop_test_step
       lifecycle.stop_test_step
 
-      aggregate_failures "should have stopped both step" do
+      aggregate_failures "should have stopped both steps" do
         expect(@test_step.steps.last.stage).to eq(Allure::Stage::FINISHED)
         expect(@test_step.stage).to eq(Allure::Stage::FINISHED)
       end


### PR DESCRIPTION
* Remove second copy of lifecycle and custom lifecycle injection in to rspec example instance
* Refactor allure-ruby-commons tests

<!-- allure -->
---
📝 [Latest allure report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/267/merge/843109234/index.html)
<!-- allurestop -->