### PR TITLE
Different test environments support

### DIFF
--- a/allure-cucumber/lib/allure-cucumber.rb
+++ b/allure-cucumber/lib/allure-cucumber.rb
@@ -9,13 +9,13 @@ require_rel "allure_cucumber"
 module AllureCucumber
   class << self
     # Get allure cucumber configuration
-    # @return [Allure::CucumberConfig]
+    # @return [AllureCucumber::CucumberConfig]
     def configuration
       CucumberConfig.instance
     end
 
     # Set allure configuration
-    # @yieldparam [Allure::CucumberConfig]
+    # @yieldparam [AllureCucumber::CucumberConfig]
     # @yieldreturn [void]
     # @return [void]
     def configure

--- a/allure-cucumber/lib/allure_cucumber/config.rb
+++ b/allure-cucumber/lib/allure_cucumber/config.rb
@@ -31,7 +31,9 @@ module AllureCucumber
                    :logging_level,
                    :logging_level=,
                    :results_directory,
-                   :results_directory=
+                   :results_directory=,
+                   :environment,
+                   :environment=
 
     attr_writer :tms_prefix, :issue_prefix, :severity_prefix
 

--- a/allure-cucumber/lib/allure_cucumber/config.rb
+++ b/allure-cucumber/lib/allure_cucumber/config.rb
@@ -3,8 +3,23 @@
 require "singleton"
 
 module AllureCucumber
-  # Allure cucumber configuration
-  class CucumberConfig < Allure::Config
+  # Allure Cucumber configuration class
+  #
+  # @!attribute results_directory
+  #   @return [String]
+  # @!attribute clean_results_directory
+  #   @return [Boolean]
+  # @!attribute link_issue_pattern
+  #   @return [String]
+  # @!attribute link_tms_pattern
+  #   @return [String]
+  # @!attribute logging_level
+  #   @return [Integer]
+  # @!attribute [r] logger
+  #   @return [Logger]
+  # @!attribute environment
+  #   @return [String]
+  class CucumberConfig
     include Singleton
     extend Forwardable
 
@@ -30,6 +45,7 @@ module AllureCucumber
                    :link_tms_pattern=,
                    :logging_level,
                    :logging_level=,
+                   :logger,
                    :results_directory,
                    :results_directory=,
                    :environment,
@@ -38,8 +54,6 @@ module AllureCucumber
     attr_writer :tms_prefix, :issue_prefix, :severity_prefix
 
     def initialize
-      super()
-
       @allure_config = Allure.configuration
     end
 

--- a/allure-cucumber/lib/allure_cucumber/formatter.rb
+++ b/allure-cucumber/lib/allure_cucumber/formatter.rb
@@ -24,7 +24,7 @@ module AllureCucumber
       Allure.lifecycle = Allure::AllureLifecycle.new(AllureCucumber.configuration)
       AllureCucumber.configuration.results_directory = config.out_stream if config.out_stream.is_a?(String)
 
-      @cucumber_model ||= AllureCucumberModel.new(config, AllureCucumber.configuration)
+      @cucumber_model ||= AllureCucumberModel.new(config, Allure.lifecycle.config)
 
       names = Allure::TestPlan.test_names
       config.name_regexps.push(*names.map { |name| /#{name}/ }) if names

--- a/allure-cucumber/lib/allure_cucumber/models/cucumber_model.rb
+++ b/allure-cucumber/lib/allure_cucumber/models/cucumber_model.rb
@@ -29,7 +29,8 @@ module AllureCucumber
         labels: parser.labels,
         links: parser.links,
         parameters: parser.parameters,
-        status_details: parser.status_details
+        status_details: parser.status_details,
+        environment: config.environment
       )
     end
 

--- a/allure-cucumber/spec/spec_helper.rb
+++ b/allure-cucumber/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "simplecov"
 require "rspec"
 require "allure-cucumber"
 require "allure-rspec"
+require "climate_control"
 
 require_relative "cucumber_helper"
 
@@ -22,6 +23,9 @@ end
 RSpec.shared_context("allure mock") do
   let(:config) do
     AllureCucumber::CucumberConfig.send(:new).tap do |conf|
+      conf.instance_variable_set(:@allure_config, Allure::Config.send(:new))
+
+      conf.results_directory = "tmp/allure-results"
       conf.link_tms_pattern = "http://www.jira.com/tms/{}"
       conf.link_issue_pattern = "http://www.jira.com/issue/{}"
     end

--- a/allure-cucumber/spec/unit/formatter_test_case_started_spec.rb
+++ b/allure-cucumber/spec/unit/formatter_test_case_started_spec.rb
@@ -67,6 +67,27 @@ describe "on_test_case_started" do
     end
   end
 
+  context "with allure environment", :test do
+    let(:environment) { "test" }
+
+    around do |example|
+      ClimateControl.modify(ALLURE_ENVIRONMENT: environment) { example.run }
+    end
+
+    it "prefixes test name with environment" do
+      run_cucumber_cli(<<~FEATURE)
+        Feature: Simple feature
+
+        Scenario: Add a to b
+          Given a is 5
+      FEATURE
+
+      expect(lifecycle).to have_received(:start_test_case).once do |arg|
+        expect(arg.name).to eq("#{environment}: Add a to b")
+      end
+    end
+  end
+
   context "cucumber tags" do
     it "are parsed correctly" do
       run_cucumber_cli(<<~FEATURE)

--- a/allure-rspec/lib/allure-rspec.rb
+++ b/allure-rspec/lib/allure-rspec.rb
@@ -8,13 +8,13 @@ require_rel "allure_rspec/**/*.rb"
 module AllureRspec
   class << self
     # Get allure cucumber configuration
-    # @return [RspecConfig]
+    # @return [AllureRspec::RspecConfig]
     def configuration
       RspecConfig.instance
     end
 
     # Set allure configuration
-    # @yieldparam [RspecConfig]
+    # @yieldparam [AllureRspec::RspecConfig]
     # @yieldreturn [void]
     # @return [void]
     def configure

--- a/allure-rspec/lib/allure_rspec/config.rb
+++ b/allure-rspec/lib/allure_rspec/config.rb
@@ -3,8 +3,23 @@
 require "singleton"
 
 module AllureRspec
-  # Shorthand configuration class
-  class RspecConfig < Allure::Config
+  # Allure RSpec configuration class
+  #
+  # @!attribute results_directory
+  #   @return [String]
+  # @!attribute clean_results_directory
+  #   @return [Boolean]
+  # @!attribute link_issue_pattern
+  #   @return [String]
+  # @!attribute link_tms_pattern
+  #   @return [String]
+  # @!attribute logging_level
+  #   @return [Integer]
+  # @!attribute [r] logger
+  #   @return [Logger]
+  # @!attribute environment
+  #   @return [String]
+  class RspecConfig
     include Singleton
     extend Forwardable
 
@@ -17,14 +32,13 @@ module AllureRspec
                    :link_tms_pattern=,
                    :logging_level,
                    :logging_level=,
+                   :logger,
                    :results_directory,
                    :results_directory=,
                    :environment,
                    :environment=
 
     def initialize
-      super()
-
       @allure_config = Allure.configuration
     end
   end

--- a/allure-rspec/lib/allure_rspec/config.rb
+++ b/allure-rspec/lib/allure_rspec/config.rb
@@ -18,7 +18,9 @@ module AllureRspec
                    :logging_level,
                    :logging_level=,
                    :results_directory,
-                   :results_directory=
+                   :results_directory=,
+                   :environment,
+                   :environment=
 
     def initialize
       super()

--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -101,7 +101,8 @@ module AllureRspec
         full_name: example.full_description,
         labels: parser.labels,
         links: parser.links,
-        status_details: parser.status_details
+        status_details: parser.status_details,
+        environment: lifecycle.config.environment
       )
     end
 

--- a/allure-rspec/spec/spec_helper.rb
+++ b/allure-rspec/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "simplecov"
 require "rspec"
 require "allure-rspec"
+require "climate_control"
 
 require_relative "rspec_runner_helper"
 
@@ -21,6 +22,9 @@ end
 RSpec.shared_context("allure mock") do
   let(:config) do
     AllureRspec::RspecConfig.send(:new).tap do |conf|
+      conf.instance_variable_set(:@allure_config, Allure::Config.send(:new))
+
+      conf.results_directory = "tmp/allure-results"
       conf.link_tms_pattern = "http://www.jira.com/tms/{}"
       conf.link_issue_pattern = "http://www.jira.com/issue/{}"
     end

--- a/allure-rspec/spec/unit/formatter_example_started_spec.rb
+++ b/allure-rspec/spec/unit/formatter_example_started_spec.rb
@@ -53,6 +53,29 @@ describe "example_started" do
     end
   end
 
+  context "allure environment" do
+    let(:environment) { "test" }
+
+    around do |example|
+      ClimateControl.modify(ALLURE_ENVIRONMENT: environment) { example.run }
+    end
+
+    it "prefixes test name with environment", :test do
+      run_rspec(<<~SPEC)
+        describe "#{suite}" do
+          it "#{spec}" do
+          end
+        end
+      SPEC
+
+      expect(lifecycle).to have_received(:start_test_case).once do |arg|
+        aggregate_failures "Should have correct args" do
+          expect(arg.name).to eq("#{environment}: spec")
+        end
+      end
+    end
+  end
+
   context "special rspec tags" do
     it "are skipped in test case generic labels" do
       run_rspec(<<~SPEC)

--- a/allure-ruby-commons/README.md
+++ b/allure-ruby-commons/README.md
@@ -20,9 +20,11 @@ Following configuration options are supported:
 
 ```ruby
     Allure.configure do |config|
-      config.results_directory = "/whatever/you/like"
+      config.results_directory = "report/allure-results"
       config.clean_results_directory = true
       config.logging_level = Logger::INFO
+      config.environment = "staging"
+
       # these are used for creating links to bugs or test cases where {} is replaced with keys of relevant items
       config.link_tms_pattern = "http://www.jira.com/browse/{}"
       config.link_issue_pattern = "http://www.jira.com/browse/{}"
@@ -34,6 +36,13 @@ Getting the configuration object:
 ```ruby
 Allure.configuration
 ```
+
+### Allure environment
+
+It is possible to set up custom allure environment which will be used to prefix test case names. This is useful if you run same tests on different environments and generate single report. This way different runs are not put as retry. Environment can be configured in following ways:
+
+* via `ALLURE_ENVIRONMENT` environment variable
+* via `configure` method
 
 ### Log level
 

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -11,7 +11,7 @@ module Allure
     # @return [Array<String>] valid log levels
     LOGLEVELS = %w[DEBUG INFO WARN ERROR FATAL UNKNOWN].freeze
 
-    attr_writer :environmnet
+    attr_writer :environment
 
     attr_accessor :results_directory,
                   :logging_level,

--- a/allure-ruby-commons/lib/allure_ruby_commons/config.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/config.rb
@@ -11,11 +11,26 @@ module Allure
     # @return [Array<String>] valid log levels
     LOGLEVELS = %w[DEBUG INFO WARN ERROR FATAL UNKNOWN].freeze
 
-    attr_accessor :results_directory, :logging_level, :link_tms_pattern, :link_issue_pattern, :clean_results_directory
+    attr_writer :environmnet
+
+    attr_accessor :results_directory,
+                  :logging_level,
+                  :link_tms_pattern,
+                  :link_issue_pattern,
+                  :clean_results_directory
 
     def initialize
       @results_directory = "reports/allure-results"
       @logging_level = LOGLEVELS.index(ENV.fetch("ALLURE_LOG_LEVEL", "INFO")) || Logger::INFO
+    end
+
+    # Allure environment
+    #
+    # @return [String]
+    def environment
+      return(@environment) if defined?(@environment)
+
+      @environment ||= ENV["ALLURE_ENVIRONMENT"]
     end
 
     # Logger instance

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/executable_item.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/executable_item.rb
@@ -27,9 +27,16 @@ module Allure
       @parameters = options[:parameters] || []
     end
 
-    attr_accessor(
-      :name, :status, :status_details, :stage, :description, :description_html,
-      :steps, :attachments, :parameters, :start, :stop
-    )
+    attr_accessor :name,
+                  :status,
+                  :status_details,
+                  :stage,
+                  :description,
+                  :description_html,
+                  :steps,
+                  :attachments,
+                  :parameters,
+                  :start,
+                  :stop
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
@@ -5,6 +5,7 @@ module Allure
   class TestResult < ExecutableItem
     # @param [String] uuid
     # @param [String] history_id
+    # @param [String] environment
     # @param [Hash] options
     # @option options [String] :name
     # @option options [String] :full_name
@@ -18,8 +19,10 @@ module Allure
     # @option options [Array<Allure::Link>] :links ([])
     # @option options [Array<Allure::Attachment>] :attachments ([])
     # @option options [Array<Allure::Parameter>] :parameters ([])
-    def initialize(uuid: UUID.generate, history_id: UUID.generate, **options)
+    def initialize(uuid: UUID.generate, history_id: UUID.generate, environment: nil, **options)
       super
+
+      @name = test_name(options[:name], environment)
       @uuid = uuid
       @history_id = history_id
       @full_name = options[:full_name] || "Unnamed"
@@ -27,6 +30,23 @@ module Allure
       @links = options[:links] || []
     end
 
-    attr_accessor :uuid, :history_id, :full_name, :labels, :links
+    attr_accessor :uuid,
+                  :history_id,
+                  :full_name,
+                  :labels,
+                  :links
+
+    private
+
+    # Test name prefixed with allure environment
+    #
+    # @param [String] name
+    # @param [String] environment
+    # @return [String]
+    def test_name(name, environment)
+      return name unless environment
+
+      "#{environment}: #{name}"
+    end
   end
 end

--- a/allure-ruby-commons/spec/unit/test_result_spec.rb
+++ b/allure-ruby-commons/spec/unit/test_result_spec.rb
@@ -3,43 +3,43 @@
 describe "AllureLifecycle::TestCaseResult" do
   include_context "lifecycle mocks"
 
-  context "without exceptions" do
-    before do
-      @result_container = start_test_container("Test Container")
-      @test_case = start_test_case(name: "Test Case")
-    end
+  let!(:result_container) { @result_container = start_test_container("Test Container") }
+  let!(:test_case) { start_test_case(name: "Test Case", environment: environment) }
+
+  context "without allure environment" do
+    let(:environment) { nil }
 
     it "starts test case" do
       aggregate_failures "Should start test and add to test container" do
-        expect(@test_case.start).to be_a(Numeric)
-        expect(@test_case.stage).to eq(Allure::Stage::RUNNING)
-        expect(@result_container.children.last).to eq(@test_case.uuid)
+        expect(test_case.start).to be_a(Numeric)
+        expect(test_case.stage).to eq(Allure::Stage::RUNNING)
+        expect(result_container.children.last).to eq(test_case.uuid)
       end
     end
 
     it "updates test case" do
       lifecycle.update_test_case { |test| test.full_name = "Full name: Test" }
 
-      expect(@test_case.full_name).to eq("Full name: Test")
+      expect(test_case.full_name).to eq("Full name: Test")
     end
 
     it "stops test" do
       lifecycle.stop_test_case
 
       aggregate_failures "Should update parameters" do
-        expect(@test_case.stop).to be_a(Numeric)
-        expect(@test_case.stage).to eq(Allure::Stage::FINISHED)
+        expect(test_case.stop).to be_a(Numeric)
+        expect(test_case.stage).to eq(Allure::Stage::FINISHED)
       end
     end
 
     it "calls file writer on stop" do
       lifecycle.stop_test_case
 
-      expect(file_writer).to have_received(:write_test_result).with(@test_case)
+      expect(file_writer).to have_received(:write_test_result).with(test_case)
     end
 
     it "adds default labels" do
-      expect(@test_case.labels).to include(
+      expect(test_case.labels).to include(
         Allure::Label.new("thread", Thread.current.object_id),
         Allure::Label.new("host", Socket.gethostname),
         Allure::Label.new("language", "ruby")
@@ -47,16 +47,11 @@ describe "AllureLifecycle::TestCaseResult" do
     end
   end
 
-  context "logs error" do
-    it "no running container" do
-      start_test_case(name: "Test Case")
-    end
+  context "with allure environment" do
+    let(:environment) { "test" }
 
-    it "no running test" do
-      start_test_container("Test Container")
-
-      lifecycle.update_test_case { |t| t.full_name = "Test" }
-      lifecycle.stop_test_case
+    it "starts test case in allure environment" do
+      expect(test_case.name).to eq("test: Test Case")
     end
   end
 end


### PR DESCRIPTION
Add support for custom allure environments:

Environment is provided via:

* `ALLURE_ENVIRONMENT` environment variable
* `Config.environment` accessor

Allure environment value will be prefixed to test names if present in order to separate same tests running in different environments

<!-- allure -->
---
📝 [Latest allure report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/268/merge/845510770/index.html)
<!-- allurestop -->