### PR TITLE
Consistent lifecycle and config access by formatters

### DIFF
--- a/allure-cucumber/lib/allure_cucumber/formatter.rb
+++ b/allure-cucumber/lib/allure_cucumber/formatter.rb
@@ -5,8 +5,6 @@ require "cucumber/core"
 module AllureCucumber
   # Main formatter class. Translates cucumber event to allure lifecycle
   class CucumberFormatter
-    extend Forwardable
-
     # @return [Hash] hook handler methods
     HOOK_HANDLERS = {
       "Before hook" => :start_prepare_fixture,
@@ -21,10 +19,12 @@ module AllureCucumber
 
     # @param [Cucumber::Configuration] config
     def initialize(config)
-      Allure.lifecycle = Allure::AllureLifecycle.new(AllureCucumber.configuration)
-      AllureCucumber.configuration.results_directory = config.out_stream if config.out_stream.is_a?(String)
+      allure_config = AllureCucumber.configuration
 
-      @cucumber_model ||= AllureCucumberModel.new(config, Allure.lifecycle.config)
+      Allure.lifecycle = @lifecycle = Allure::AllureLifecycle.new(allure_config)
+      allure_config.results_directory = config.out_stream if config.out_stream.is_a?(String)
+
+      @cucumber_model ||= AllureCucumberModel.new(config, allure_config)
 
       names = Allure::TestPlan.test_names
       config.name_regexps.push(*names.map { |name| /#{name}/ }) if names
@@ -89,9 +89,7 @@ module AllureCucumber
 
     private
 
-    def_delegator :Allure, :lifecycle
-
-    attr_reader :cucumber_model
+    attr_reader :lifecycle, :cucumber_model
 
     # Is hook fixture like Before, After or Step as AfterStep
     # @param [String] text

--- a/allure-cucumber/spec/spec_helper.rb
+++ b/allure-cucumber/spec/spec_helper.rb
@@ -30,10 +30,11 @@ RSpec.shared_context("allure mock") do
       conf.link_issue_pattern = "http://www.jira.com/issue/{}"
     end
   end
-  let(:lifecycle) { spy("lifecycle", config: config) }
+  let(:lifecycle) { spy("lifecycle") }
 
   before do
     allow(Allure::AllureLifecycle).to receive(:new) { lifecycle }
+    allow(AllureCucumber).to receive(:configuration) { config }
   end
 end
 

--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -8,7 +8,6 @@ module AllureRspec
   # Main rspec formatter class translating rspec events to allure lifecycle
   class RSpecFormatter < RSpec::Core::Formatters::BaseFormatter
     include Utils
-    extend Forwardable
 
     # @return [Hash] allure statuses mapping
     ALLURE_STATUS = {
@@ -37,7 +36,8 @@ module AllureRspec
     def initialize(output)
       super
 
-      Allure.lifecycle = Allure::AllureLifecycle.new(AllureRspec.configuration)
+      @allure_config = AllureRspec.configuration
+      Allure.lifecycle = @lifecycle = Allure::AllureLifecycle.new(@allure_config)
     end
 
     # Start test run
@@ -85,13 +85,13 @@ module AllureRspec
 
     private
 
-    def_delegator :Allure, :lifecycle
+    attr_reader :lifecycle, :allure_config
 
     # Transform example to <Allure::TestResult>
     # @param [RSpec::Core::Example] example
     # @return [Allure::TestResult]
     def test_result(example)
-      parser = RspecMetadataParser.new(example, lifecycle.config)
+      parser = RspecMetadataParser.new(example, allure_config)
 
       Allure::TestResult.new(
         name: example.description,
@@ -102,7 +102,7 @@ module AllureRspec
         labels: parser.labels,
         links: parser.links,
         status_details: parser.status_details,
-        environment: lifecycle.config.environment
+        environment: allure_config.environment
       )
     end
 

--- a/allure-rspec/spec/spec_helper.rb
+++ b/allure-rspec/spec/spec_helper.rb
@@ -30,10 +30,11 @@ RSpec.shared_context("allure mock") do
     end
   end
 
-  let(:lifecycle) { spy("lifecycle", config: config) }
+  let(:lifecycle) { spy("lifecycle") }
 
   before do
     allow(Allure::AllureLifecycle).to receive(:new) { lifecycle }
+    allow(AllureRspec).to receive(:configuration) { config }
   end
 end
 


### PR DESCRIPTION
<!-- allure -->
---
📝 [Latest allure report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/271/merge/849506767/index.html)
<!-- allurestop -->