### PR TITLE
RSpec: Ability to configure special allure tags

### DIFF
--- a/allure-cucumber/lib/allure_cucumber/config.rb
+++ b/allure-cucumber/lib/allure_cucumber/config.rb
@@ -52,7 +52,12 @@ module AllureCucumber
                    :environment,
                    :environment=
 
-    attr_writer :tms_prefix, :issue_prefix, :severity_prefix
+    attr_writer :tms_prefix,
+                :issue_prefix,
+                :severity_prefix,
+                :epic_prefix,
+                :feature_prefix,
+                :story_prefix
 
     def initialize
       @allure_config = Allure.configuration

--- a/allure-rspec/README.md
+++ b/allure-rspec/README.md
@@ -56,11 +56,12 @@ end
 
 ### Adding tms links
 
-Configure tms link pattern:
+Configure tms link pattern and rspec tag:
 
 ```ruby
 AllureRspec.configure do |config|
   config.link_tms_pattern = "http://www.jira.com/browse/{}"
+  config.tms_tag = :tms
 end
 ```
 
@@ -87,6 +88,7 @@ Configure issue link pattern:
 ```ruby
 AllureRspec.configure do |config|
   config.link_issue_pattern = "http://www.jira.com/browse/{}"
+  config.issue_tag = :issue
 end
 ```
 
@@ -108,7 +110,15 @@ end
 
 ### Adding custom severity and status details
 
-Test severity (`normal` by default) can be changed via `severity` tag:
+Configure severity tag:
+
+```ruby
+AllureRspec.configure do |config|
+  config.severity_tag = :severity
+end
+```
+
+Test severity is set to `normal` by default:
 
 ```ruby
 it "some test case", severity: :critical do
@@ -134,9 +144,20 @@ it "some test case", allure_1: "visual_test", allure_2: "core_functionality" do
 end
 ```
 
+All rspec metadata tags will also be added as labels in test report.
+
 ### Behavior driven test grouping
 
-Marking tests with tags `:epic, :feature, :story`, will group tests accordingly in Behavior report tab:
+Marking tests with tags `:epic, :feature, :story`, will group tests accordingly in Behavior report tab.\
+Tag values can also be configured:
+
+```ruby
+AllureRspec.configure do |config|
+  config.epic_tag = :epic
+  config.feature_tag = :feature
+  config.story_tag = :story
+end
+```
 
 ```ruby
 context "context", feature: "my feature"  do

--- a/allure-rspec/lib/allure_rspec/config.rb
+++ b/allure-rspec/lib/allure_rspec/config.rb
@@ -23,6 +23,19 @@ module AllureRspec
     include Singleton
     extend Forwardable
 
+    # @return [Symbol] default tms tag
+    DEFAULT_TMS_TAG = :tms
+    # @return [Symbol] default issue tag
+    DEFAULT_ISSUE_TAG = :issue
+    # @return [Symbol] default severity tag
+    DEFAULT_SEVERITY_TAG = :severity
+    # @return [Symbol] default epic tag
+    DEFAULT_EPIC_TAG = :epic
+    # @return [Symbol] default feature tag
+    DEFAULT_FEATURE_TAG = :feature
+    # @return [Symbol] default story tag
+    DEFAULT_STORY_TAG = :story
+
     def_delegators :@allure_config,
                    :clean_results_directory,
                    :clean_results_directory=,
@@ -41,6 +54,38 @@ module AllureRspec
 
     def initialize
       @allure_config = Allure.configuration
+    end
+
+    attr_writer :tms_tag, :issue_tag, :severity_tag, :epic_tag, :feature_tag, :story_tag
+
+    # @return [Symbol]
+    def tms_tag
+      @tms_prefix || DEFAULT_TMS_TAG
+    end
+
+    # @return [Symbol]
+    def issue_tag
+      @issue_prefix || DEFAULT_ISSUE_TAG
+    end
+
+    # @return [Symbol]
+    def severity_tag
+      @severity_prefix || DEFAULT_SEVERITY_TAG
+    end
+
+    # @return [Symbol]
+    def epic_tag
+      @epic_prefix || DEFAULT_EPIC_TAG
+    end
+
+    # @return [Symbol]
+    def feature_tag
+      @feature_prefix || DEFAULT_FEATURE_TAG
+    end
+
+    # @return [Symbol]
+    def story_tag
+      @story_prefix || DEFAULT_STORY_TAG
     end
   end
 end

--- a/allure-rspec/lib/allure_rspec/config.rb
+++ b/allure-rspec/lib/allure_rspec/config.rb
@@ -56,7 +56,12 @@ module AllureRspec
       @allure_config = Allure.configuration
     end
 
-    attr_writer :tms_tag, :issue_tag, :severity_tag, :epic_tag, :feature_tag, :story_tag
+    attr_writer :tms_tag,
+                :issue_tag,
+                :severity_tag,
+                :epic_tag,
+                :feature_tag,
+                :story_tag
 
     # @return [Symbol]
     def tms_tag

--- a/allure-rspec/lib/allure_rspec/metadata_parser.rb
+++ b/allure-rspec/lib/allure_rspec/metadata_parser.rb
@@ -69,7 +69,11 @@ module AllureRspec
 
     private
 
-    attr_reader :example, :config
+    # @return [RSpec::Core::Example]
+    attr_reader :example
+
+    # @return [AllureRspec::RspecConfig]
+    attr_reader :config
 
     # Example metadata
     #
@@ -100,7 +104,7 @@ module AllureRspec
     # Get severity
     # @return [String]
     def severity
-      Allure::ResultUtils.severity_label(metadata[:severity] || "normal")
+      Allure::ResultUtils.severity_label(metadata[config.severity_tag] || "normal")
     end
 
     # Get test suite labels
@@ -121,9 +125,9 @@ module AllureRspec
     # @return [Array<Allure::Label>]
     def behavior_labels
       metadata = example.metadata
-      epic = metadata[:epic] || Pathname.new(strip_relative(example.file_path)).parent.to_s
-      feature = metadata[:feature] || example.example_group.description
-      story = metadata[:story]
+      epic = metadata[config.epic_tag] || Pathname.new(strip_relative(example.file_path)).parent.to_s
+      feature = metadata[config.feature_tag] || example.example_group.description
+      story = metadata[config.story_tag]
 
       [
         Allure::ResultUtils.epic_label(epic),
@@ -149,7 +153,12 @@ module AllureRspec
     # @param [Symbol] key
     # @return [boolean]
     def special_metadata_tag?(key)
-      tms?(key) || issue?(key) || %i[severity epic feature story].include?(key)
+      tms?(key) || issue?(key) || [
+        config.severity_tag,
+        config.epic_tag,
+        config.feature_tag,
+        config.story_tag
+      ].include?(key)
     end
 
     # Does key match custom allure label
@@ -163,14 +172,14 @@ module AllureRspec
     # @param [Symbol] key
     # @return [boolean]
     def tms?(key)
-      key.to_s.match?(/tms(_\d+)?/i)
+      key.to_s.match?(/#{config.tms_tag}(_\d+)?/i)
     end
 
     # Does key match issue pattern
     # @param [Symbol] key
     # @return [boolean]
     def issue?(key)
-      key.to_s.match?(/issue(_\d+)?/i)
+      key.to_s.match?(/#{config.issue_tag}(_\d+)?/i)
     end
   end
 end


### PR DESCRIPTION
* Adds ability to change values for `epic`, `feature`, `story`, `severity`, `issue` and `tms tags`

<!-- allure -->
---
📝 [Latest allure report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/272/merge/850359085/index.html)
<!-- allurestop -->