### PR TITLE
Use prefix/tag for link names if full url used

### DIFF
--- a/allure-cucumber/lib/allure_cucumber/models/metadata_parser.rb
+++ b/allure-cucumber/lib/allure_cucumber/models/metadata_parser.rb
@@ -100,12 +100,15 @@ module AllureCucumber
     # @return [Array<Allure::Link>]
     def matching_links(type)
       pattern = reserved_patterns[type]
+      prefix = config.tms_prefix
       link_pattern = config.public_send("link_#{type}_pattern")
 
       tags
         .select { |tag| tag.match?(pattern) }
         .map do |tag|
-          tag.match(pattern) { |match| Allure::ResultUtils.public_send("#{type}_link", match[type], link_pattern) }
+          tag.match(pattern) do |match|
+            Allure::ResultUtils.public_send("#{type}_link", prefix, match[type], link_pattern)
+          end
         end
     end
 

--- a/allure-cucumber/spec/unit/formatter_test_case_started_spec.rb
+++ b/allure-cucumber/spec/unit/formatter_test_case_started_spec.rb
@@ -159,8 +159,8 @@ describe "on_test_case_started" do
       expect(lifecycle).to have_received(:start_test_case).once do |arg|
         expect(arg.links).to match_array(
           [
-            result_utils.tms_link("OAT-4444", link_tms_pattern),
-            result_utils.issue_link("BUG-22400", link_issue_pattern)
+            result_utils.tms_link("tms", "OAT-4444", link_tms_pattern),
+            result_utils.issue_link("issue", "BUG-22400", link_issue_pattern)
           ]
         )
       end

--- a/allure-rspec/lib/allure_rspec/metadata_parser.rb
+++ b/allure-rspec/lib/allure_rspec/metadata_parser.rb
@@ -144,8 +144,8 @@ module AllureRspec
       return [] unless link_pattern
 
       metadata
-        .select { |k| __send__("#{type}?", k) }.values
-        .map { |v| Allure::ResultUtils.public_send("#{type}_link", v, link_pattern) }
+        .select { |key| __send__("#{type}?", key) }
+        .map { |key, value| Allure::ResultUtils.public_send("#{type}_link", key.to_s, value, link_pattern) }
     end
 
     # Special allure metadata tags

--- a/allure-rspec/spec/unit/formatter_example_started_spec.rb
+++ b/allure-rspec/spec/unit/formatter_example_started_spec.rb
@@ -130,10 +130,10 @@ describe "example_started" do
       expect(lifecycle).to have_received(:start_test_case).once do |arg|
         expect(arg.links).to match_array(
           [
-            result_utils.tms_link("QA-123", link_tms_pattern),
-            result_utils.tms_link("QA-124", link_tms_pattern),
-            result_utils.issue_link("BUG-123", link_issue_pattern),
-            result_utils.issue_link("BUG-124", link_issue_pattern)
+            result_utils.tms_link("tms", "QA-123", link_tms_pattern),
+            result_utils.tms_link("tms", "QA-124", link_tms_pattern),
+            result_utils.issue_link("issue", "BUG-123", link_issue_pattern),
+            result_utils.issue_link("issue", "BUG-124", link_issue_pattern)
           ]
         )
       end

--- a/allure-ruby-commons/lib/allure_ruby_commons/result_utils.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/result_utils.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "socket"
+require "uri"
 
 module Allure
   # Variouse helper methods
@@ -133,16 +134,18 @@ module Allure
       # @param [String] value
       # @param [String] link_pattern
       # @return [Allure::Link]
-      def tms_link(value, link_pattern)
-        Link.new(TMS_LINK_TYPE, value, url(value, link_pattern))
+      def tms_link(name, value, link_pattern)
+        link_name = url?(value) ? name : value
+        Link.new(TMS_LINK_TYPE, link_name, url(value, link_pattern))
       end
 
       # Issue link
       # @param [String] value
       # @param [String] link_pattern
       # @return [Allure::Link]
-      def issue_link(value, link_pattern)
-        Link.new(ISSUE_LINK_TYPE, value, url(value, link_pattern))
+      def issue_link(name, value, link_pattern)
+        link_name = url?(value) ? name : value
+        Link.new(ISSUE_LINK_TYPE, link_name, url(value, link_pattern))
       end
 
       # Get status based on exception type
@@ -171,6 +174,19 @@ module Allure
 
       private
 
+      # Check if value is full url
+      #
+      # @param [String] value
+      # @return [Boolean]
+      def url?(value)
+        URI.parse(value.to_s).scheme
+      end
+
+      # Construct url from pattern
+      #
+      # @param [String] value
+      # @param [String] link_pattern
+      # @return [String]
       def url(value, link_pattern)
         link_pattern.sub("{}", value)
       end

--- a/allure-ruby-commons/spec/unit/result_utils_spec.rb
+++ b/allure-ruby-commons/spec/unit/result_utils_spec.rb
@@ -49,11 +49,19 @@ describe Allure::ResultUtils do
   end
 
   it "returns tms link" do
-    expect(utils.tms_link("123", "http://jira.com/{}")).to eq(Allure::Link.new("tms", "123", "http://jira.com/123"))
+    expect(utils.tms_link("tms", "123", "http://jira.com/{}")).to eq(Allure::Link.new("tms", "123", "http://jira.com/123"))
+  end
+
+  it "returns tms link with value as full url" do
+    expect(utils.tms_link("tms", "http://jira.com/123", "{}")).to eq(Allure::Link.new("tms", "tms", "http://jira.com/123"))
   end
 
   it "returns issue link" do
-    expect(utils.issue_link("123", "http://jira.com/{}")).to eq(Allure::Link.new("issue", "123", "http://jira.com/123"))
+    expect(utils.issue_link("issue", "123", "http://jira.com/{}")).to eq(Allure::Link.new("issue", "123", "http://jira.com/123"))
+  end
+
+  it "returns issue link with value as full url" do
+    expect(utils.issue_link("issue", "http://jira.com/123", "{}")).to eq(Allure::Link.new("issue", "issue", "http://jira.com/123"))
   end
 
   it "returns correct status for expectation error" do


### PR DESCRIPTION
In case full url is used for issue and tms links, don't use full url as name in report