### PR TITLE
Remove global default Oj options

### DIFF
--- a/allure-ruby-commons/lib/allure_ruby_commons/file_writer.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/file_writer.rb
@@ -13,6 +13,8 @@ module Allure
     ENVIRONMENT_FILE = "environment.properties"
     # @return [String] categories definition json
     CATEGORIES_FILE = "categories.json"
+    # @return [Hash] Oj json options
+    OJ_OPTIONS = { mode: :custom, use_to_hash: true, ascii_only: true }.freeze
 
     # File writer instance
     #
@@ -25,14 +27,14 @@ module Allure
     # @param [Allure::TestResult] test_result
     # @return [void]
     def write_test_result(test_result)
-      write("#{test_result.uuid}#{TEST_RESULT_SUFFIX}", Oj.dump(test_result))
+      write("#{test_result.uuid}#{TEST_RESULT_SUFFIX}", Oj.dump(test_result, OJ_OPTIONS))
     end
 
     # Write test result container
     # @param [Allure::TestResultContainer] test_container_result
     # @return [void]
     def write_test_result_container(test_container_result)
-      write("#{test_container_result.uuid}#{TEST_RESULT_CONTAINER_SUFFIX}", Oj.dump(test_container_result))
+      write("#{test_container_result.uuid}#{TEST_RESULT_CONTAINER_SUFFIX}", Oj.dump(test_container_result, OJ_OPTIONS))
     end
 
     # Write allure attachment file
@@ -59,7 +61,7 @@ module Allure
       if categories.is_a?(File)
         copy(categories.path, CATEGORIES_FILE)
       else
-        write(CATEGORIES_FILE, Oj.dump(categories))
+        write(CATEGORIES_FILE, Oj.dump(categories, OJ_OPTIONS))
       end
     end
 

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/01_jsonable.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/01_jsonable.rb
@@ -5,8 +5,6 @@ require "oj"
 module Allure
   # General jsonable object implementation
   class JSONable
-    Oj.default_options = { mode: :custom, use_to_hash: true, ascii_only: true }
-
     # Return object hash represantation
     # @return [Hash]
     def to_hash


### PR DESCRIPTION
Related to: https://github.com/allure-framework/allure-ruby/issues/335

By not relying on global options, this should make sure if project already uses Oj, it's not impacted by whatever options the project might be setting.