### PR TITLE
Making file_writer lazily initialized

### DIFF
--- a/allure-ruby-commons/lib/allure_ruby_commons/allure_lifecycle.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/allure_lifecycle.rb
@@ -16,7 +16,6 @@ module Allure
       @step_context = []
       @config = config
       @logger = config.logger
-      @file_writer = FileWriter.new(config.results_directory)
     end
 
     attr_reader :config
@@ -259,7 +258,11 @@ module Allure
 
     private
 
-    attr_reader :logger, :file_writer
+    attr_reader :logger
+
+    def file_writer
+      @file_writer ||= FileWriter.new(config.results_directory)
+    end
 
     def current_executable
       current_test_step || @current_fixture || @current_test_case


### PR DESCRIPTION
The `config.results_directory` string is being passed into the `FileWriter`
initializer. The `results_directory` can be changed via the `Allure.configure`
block. Since ruby passes strings by value, this necessitates that the
`Allure.configure` block be called prior to initializing the
`AllureLifecycle` object.

Moving the `FileWriter` to an instance method and memoizing such that it
will be initialized right before it is used for the first time. Thus
allowing for a less strict ordering.