### PR TITLE
Update allure report publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,8 @@ jobs:
         env:
           GOOGLE_CLOUD_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CLOUD_CREDENTIALS_JSON }}
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ALLURE_PUBLISHER_IMAGE: andrcuns/allure-report-publisher:0.5.0
+          ALLURE_PUBLISHER_VERSION: "0.5.1"
         run: |
-          docker pull -q ${ALLURE_PUBLISHER_IMAGE}; \
           docker run --rm \
             -v "$GITHUB_WORKSPACE":/workspace \
             -v "$GITHUB_EVENT_PATH":"$GITHUB_EVENT_PATH" \
@@ -85,7 +84,7 @@ jobs:
             -e GITHUB_EVENT_PATH="$GITHUB_EVENT_PATH" \
             -e ALLURE_JOB_NAME="rspec-3.0" \
             -e GOOGLE_CLOUD_CREDENTIALS_JSON="$GOOGLE_CLOUD_CREDENTIALS_JSON" \
-            ${ALLURE_PUBLISHER_IMAGE} \
+            andrcuns/allure-report-publisher:${ALLURE_PUBLISHER_VERSION} \
             upload gcs \
               --results-glob="/workspace/*/reports/allure-results/*" \
               --bucket="allure-test-reports" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Ruby 3.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0.3"
+          ruby-version: "3.0"
           bundler-cache: true
       - name: Lint
         run: bundle exec rake rubocop
@@ -29,7 +29,7 @@ jobs:
     needs: rubocop
     strategy:
       matrix:
-        ruby: ["2.6", "2.7", "3.0.3"]
+        ruby: ["2.6", "2.7", "3.0"]
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GOOGLE_CLOUD_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CLOUD_CREDENTIALS_JSON }}
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ALLURE_PUBLISHER_IMAGE: andrcuns/allure-report-publisher:0.4.2
+          ALLURE_PUBLISHER_IMAGE: andrcuns/allure-report-publisher:0.5.0
         run: |
           docker pull -q ${ALLURE_PUBLISHER_IMAGE}; \
           docker run --rm \
@@ -90,7 +90,8 @@ jobs:
               --results-glob="/workspace/*/reports/allure-results/*" \
               --bucket="allure-test-reports" \
               --prefix="allure-ruby/$GITHUB_REF" \
-              --update-pr="comment" \
+              --update-pr="description" \
+              --summary="behaviors" \
               --copy-latest \
               --ignore-missing-results \
               --color

--- a/allure-rspec/spec/unit/formatter_start_spec.rb
+++ b/allure-rspec/spec/unit/formatter_start_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "start", focus: true do
+describe "start" do
   include_context "allure mock"
   include_context "rspec runner"
 

--- a/allure-rspec/spec/unit/formatter_stop_spec.rb
+++ b/allure-rspec/spec/unit/formatter_stop_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "start", focus: true do
+describe "start" do
   include_context "allure mock"
   include_context "rspec runner"
 


### PR DESCRIPTION
Update allure report publisher version and post result in pr description

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec-3.0 -->
**rspec-3.0**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/366/merge/2172678259/index.html) for [7003b180](https://github.com/allure-framework/allure-ruby/pull/366/commits/7003b1808196962171057eb594d7ddba9e3fbb1b)
```markdown
+------------------------------------------------------------------+
|                        behaviors summary                         |
+---------------------+--------+--------+---------+-------+--------+
|                     | passed | failed | skipped | flaky | result |
+---------------------+--------+--------+---------+-------+--------+
| allure-cucumber     | 96     | 0      | 0       | 0     | ✅     |
| allure-ruby-commons | 270    | 0      | 0       | 0     | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | ✅     |
+---------------------+--------+--------+---------+-------+--------+
```
<!-- rspec-3.0 -->
<!-- jobs -->
<!-- allurestop -->