### PR TITLE
Bump publisher version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GOOGLE_CLOUD_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CLOUD_CREDENTIALS_JSON }}
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ALLURE_PUBLISHER_VERSION: "0.5.1"
+          ALLURE_PUBLISHER_VERSION: "0.6.0"
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE":/workspace \


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/371/merge/2213303838/index.html) for [89fad658](https://github.com/allure-framework/allure-ruby/pull/371/commits/89fad6581dc83b230bf6da0d10de893257e91416)
```markdown
+------------------------------------------------------------------+
|                        behaviors summary                         |
+---------------------+--------+--------+---------+-------+--------+
|                     | passed | failed | skipped | flaky | result |
+---------------------+--------+--------+---------+-------+--------+
| allure-cucumber     | 96     | 0      | 0       | 0     | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | ✅     |
| allure-ruby-commons | 270    | 0      | 0       | 0     | ✅     |
+---------------------+--------+--------+---------+-------+--------+
| Total               | 429    | 0      | 0       | 0     | ✅     |
+---------------------+--------+--------+---------+-------+--------+
```
<!-- rspec -->
<!-- jobs -->
<!-- allurestop -->