### PR TITLE
Allow indirect dependency updates in lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,19 @@ updates:
     prefix: deps
     prefix-development: deps-dev
   allow:
-    - dependency-type: all
+    - dependency-type: direct
+    - dependency-name: cucumber
+      dependency-type: indirect
+    - dependency-name: rspec-core
+      dependency-type: indirect
+    - dependency-name: mime-types
+      dependency-type: indirect
+    - dependency-name: oj
+      dependency-type: indirect
+    - dependency-name: require_all
+      dependency-type: indirect
+    - dependency-name: uuid
+      dependency-type: indirect
 - package-ecosystem: bundler
   directory: "/allure-rspec"
   schedule:


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/377/merge/2213364189/index.html) for [878f3cd4](https://github.com/allure-framework/allure-ruby/pull/377/commits/878f3cd411b17661f1cbf0f93463f68a042f5b46)
```markdown
+------------------------------------------------------------------+
|                        behaviors summary                         |
+---------------------+--------+--------+---------+-------+--------+
|                     | passed | failed | skipped | flaky | result |
+---------------------+--------+--------+---------+-------+--------+
| allure-ruby-commons | 270    | 0      | 0       | 0     | ✅     |
| allure-cucumber     | 96     | 0      | 0       | 0     | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | ✅     |
+---------------------+--------+--------+---------+-------+--------+
| Total               | 429    | 0      | 0       | 0     | ✅     |
+---------------------+--------+--------+---------+-------+--------+
```
<!-- rspec -->
<!-- jobs -->
<!-- allurestop -->