### PR TITLE
Use container environment for allure-report publish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish allure report
         run: |
           allure-report-publisher upload gcs \
-            --results-glob="/workspace/*/reports/allure-results/*" \
+            --results-glob="*/reports/allure-results/*" \
             --bucket="allure-test-reports" \
             --prefix="allure-ruby/$GITHUB_REF" \
             --update-pr="description" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,46 +51,32 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: allure-results
-          path: '*/reports/allure-results/*'
+          path: "*/reports/allure-results/*"
           retention-days: 1
-  
+
   report:
     name: Allure report
     runs-on: ubuntu-20.04
     needs: rspec
     if: always()
+    container:
+      image: andrcuns/allure-report-publisher:0.8.0
+      env:
+        GOOGLE_CLOUD_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CLOUD_CREDENTIALS_JSON }}
+        GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Download allure-results
         uses: actions/download-artifact@v3
         with:
           name: allure-results
       - name: Publish allure report
-        env:
-          GOOGLE_CLOUD_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CLOUD_CREDENTIALS_JSON }}
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ALLURE_PUBLISHER_VERSION: "0.6.0"
         run: |
-          docker run --rm \
-            -v "$GITHUB_WORKSPACE":/workspace \
-            -v "$GITHUB_EVENT_PATH":"$GITHUB_EVENT_PATH" \
-            -e GITHUB_WORKFLOW="$GITHUB_WORKFLOW" \
-            -e GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
-            -e GITHUB_SERVER_URL="$GITHUB_SERVER_URL" \
-            -e GITHUB_API_URL="$GITHUB_API_URL" \
-            -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
-            -e GITHUB_JOB="$GITHUB_JOB" \
-            -e GITHUB_RUN_ID="$GITHUB_RUN_ID" \
-            -e GITHUB_AUTH_TOKEN="$GITHUB_AUTH_TOKEN" \
-            -e GITHUB_EVENT_PATH="$GITHUB_EVENT_PATH" \
-            -e ALLURE_JOB_NAME="rspec" \
-            -e GOOGLE_CLOUD_CREDENTIALS_JSON="$GOOGLE_CLOUD_CREDENTIALS_JSON" \
-            andrcuns/allure-report-publisher:${ALLURE_PUBLISHER_VERSION} \
-            upload gcs \
-              --results-glob="/workspace/*/reports/allure-results/*" \
-              --bucket="allure-test-reports" \
-              --prefix="allure-ruby/$GITHUB_REF" \
-              --update-pr="description" \
-              --summary="behaviors" \
-              --copy-latest \
-              --ignore-missing-results \
-              --color
+          allure-report-publisher upload gcs \
+            --results-glob="/workspace/*/reports/allure-results/*" \
+            --bucket="allure-test-reports" \
+            --prefix="allure-ruby/$GITHUB_REF" \
+            --update-pr="description" \
+            --summary="behaviors" \
+            --copy-latest \
+            --ignore-missing-results \
+            --color


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- report -->
**report**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/393/merge/2449799590/index.html) for [4cfc8b40](https://github.com/allure-framework/allure-ruby/pull/393/commits/4cfc8b40da310b0f40aabedf7662c869d6b171d5)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 96     | 0      | 0       | 0     | 96    | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | 63    | ✅     |
| allure-ruby-commons | 270    | 0      | 0       | 0     | 270   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 429    | 0      | 0       | 0     | 429   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- report -->

<!-- jobs -->
<!-- allurestop -->