### PR TITLE
Publish report only when maintainer triggers ci run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     name: Allure report
     runs-on: ubuntu-22.04
     needs: rspec
-    if: always()
+    if: github.actor == 'andrcuns'
     steps:
       - name: Download allure-results
         uses: actions/download-artifact@v3


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/424/merge/3085491998/index.html) for [9649f2a1](https://github.com/allure-framework/allure-ruby/pull/424/commits/9649f2a14920a605fcc11b91fa362ad98e57f583)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-ruby-commons | 270    | 0      | 0       | 0     | 270   | ✅     |
| allure-cucumber     | 96     | 0      | 0       | 0     | 96    | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | 63    | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 429    | 0      | 0       | 0     | 429   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->