### PR TITLE
Add manual release workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,20 @@
+name: Changelog
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,42 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: Semver component
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-
-      - name: Set up Ruby
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
+      -
+        name: Set up Ruby 3.1
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.1.2
           bundler-cache: true
-
-      - name: Test
-        run: bundle exec rake
-
-      - name: Release
+      -
+        name: Update version
+        run: |
+          git config user.name andrcuns
+          git config user.email andrejs.cunskis@gmail.com
+          bundle config unset deployment
+          bundle exec rake "version[${{ inputs.semver }}]"
+      -
+        name: Build and push gem
         run: bundle exec rake release
         env:
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_TOKEN }}
-
-  gh-release:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: softprops/action-gh-release@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          generate_release_notes: true

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "allure-ruby-commons", path: "allure-ruby-commons"
 
 group :development do
   gem "colorize", "~> 0.8.1"
-  gem "git", "~> 1.12"
   gem "pry", "~> 0.14.1"
   gem "rake", "~> 13.0.6"
   gem "semver2", "~> 3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     ast (2.4.2)
     backport (1.2.0)
@@ -62,9 +60,6 @@ GEM
     docile (1.3.5)
     e2mmap (0.1.0)
     ffi (1.15.5)
-    git (1.12.0)
-      addressable (~> 2.8)
-      rchardet (~> 1.8)
     jaro_winkler (1.5.4)
     json (2.6.2)
     kramdown (2.4.0)
@@ -89,11 +84,9 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.7)
     racc (1.6.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    rchardet (1.8.0)
     regexp_parser (2.6.0)
     require_all (3.0.0)
     reverse_markdown (2.1.1)
@@ -177,7 +170,6 @@ DEPENDENCIES
   allure-ruby-commons!
   climate_control (~> 1.2.0)
   colorize (~> 0.8.1)
-  git (~> 1.12)
   pry (~> 0.14.1)
   rake (~> 13.0.6)
   rspec (~> 3.11.0)

--- a/lib/tasks/version.rake
+++ b/lib/tasks/version.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "semver"
-require "git"
 
 require_relative "../task_helpers/util"
 
@@ -27,11 +26,13 @@ class VersionTask
     task(:version, [:semver]) do |_task, args|
       @new_version = send(args[:semver]).format("%M.%m.%p").to_s
 
+      puts "Updating version to #{new_version}"
+
       update_version
       update_lockfile
       commit_and_tag
 
-      puts "Bumped version to #{new_version}"
+      puts "Version updated successfully!"
     end
   end
 
@@ -57,10 +58,10 @@ class VersionTask
   #
   # @return [void]
   def commit_and_tag
-    git = Git.init
-    git.add([VERSION_FILE, LOCKFILE])
-    git.commit("Update version to #{new_version}")
-    git.add_tag(new_version.to_s)
+    execute_shell("git add #{VERSION_FILE} #{LOCKFILE}")
+    execute_shell("git commit -m 'Update version to #{new_version}'")
+    execute_shell("git tag #{new_version}")
+    execute_shell("git push && git push --tags")
   end
 
   # Semver of ref from


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/433/merge/3256037702/index.html) for [2a2c861c](https://github.com/allure-framework/allure-ruby/pull/433/commits/2a2c861c76fdf25ea201305e5cd215a1e9901e18)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 96     | 0      | 0       | 0     | 96    | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | 63    | ✅     |
| allure-ruby-commons | 270    | 0      | 0       | 0     | 270   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 429    | 0      | 0       | 0     | 429   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->