### PR TITLE
Use common github labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   reviewers:
     - andrcuns
   labels:
-    - type:chore
+    - maintenance
   allow:
     - dependency-type: direct
     - dependency-name: cucumber
@@ -28,24 +28,18 @@ updates:
     interval: daily
   reviewers:
     - andrcuns
-  labels:
-    - type:dependency
 - package-ecosystem: bundler
   directory: "/allure-ruby-commons"
   schedule:
     interval: daily
   reviewers:
     - andrcuns
-  labels:
-    - type:dependency
 - package-ecosystem: bundler
   directory: "/allure-cucumber"
   schedule:
     interval: daily
   reviewers:
     - andrcuns
-  labels:
-    - type:dependency
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -53,4 +47,4 @@ updates:
   reviewers:
     - andrcuns
   labels:
-    - type:chore
+    - ci

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,19 +2,22 @@ changelog:
   categories:
     - title: '🚀 New Features'
       labels:
-        - 'type:new feature'
+        - 'feature'
     - title: '🔬 Improvements'
       labels:
-        - 'type:enhancement'
+        - 'enhancement'
     - title: '🐞 Bug Fixes'
       labels:
-        - 'type:bug'
+        - 'bug'
     - title: '📦 Dependency updates'
       labels:
-        - 'type:dependency'
+        - 'dependencies'
     - title: '📄 Documentation updates'
       labels:
-        - 'type:documentation'
-    - title: '🛠️ Maintenance'
+        - 'documentation'
+    - title: '🧰 Maintenance'
       labels:
-        - 'type:chore'
+        - 'maintenance'
+    - title: '👷 CI'
+      labels:
+        - 'ci'

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Executing test for allure-ruby-commons
 
 - Submit a PR
 
+### Releasing
+
+New version can be created by triggering manual `Release` workflow
+
 ## Generating HTML report
 
 Ruby binding hosted in this repository only generate source json files for the [allure2](https://github.com/allure-framework/allure2) reporter.


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/434/merge/3256074080/index.html) for [9d8e999b](https://github.com/allure-framework/allure-ruby/pull/434/commits/9d8e999b15ba6037fdd461b8a99cb52123074bf8)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 96     | 0      | 0       | 0     | 96    | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | 63    | ✅     |
| allure-ruby-commons | 270    | 0      | 0       | 0     | 270   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 429    | 0      | 0       | 0     | 429   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->