### PR TITLE
Clear ansi color escapes from rspec traces

### DIFF
--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -124,7 +124,7 @@ module AllureRspec
           test_case.stage = Allure::Stage::FINISHED
           test_case.status = status(result)
           test_case.status_details.message = status_detail.message
-          test_case.status_details.trace = status_detail.trace
+          test_case.status_details.trace = status_detail.trace&.gsub(/\e\[(\d+)(?:;\d+)*m/, "")
         end
       end
     end


### PR DESCRIPTION
RSpec trace can often contain ansi color escape codes. Clear these to make error messages more readable.

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/445/merge/3495112939/index.html) for [069e7674](https://github.com/allure-framework/allure-ruby/pull/445/commits/069e767426d4935075aba75155343e0fb733c42d)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 96     | 0      | 0       | 0     | 96    | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | 63    | ✅     |
| allure-ruby-commons | 270    | 0      | 0       | 0     | 270   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 429    | 0      | 0       | 0     | 429   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->