### PR TITLE
Set correct status for expect failures in steps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ PATH
       mime-types (>= 3.3, < 4)
       oj (>= 3.10, < 4)
       require_all (>= 2, < 4)
+      rspec-expectations (~> 3.12)
       uuid (>= 2.3, < 3)
 
 GEM

--- a/allure-ruby-commons/allure-ruby-commons.gemspec
+++ b/allure-ruby-commons/allure-ruby-commons.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |s|
   s.add_dependency "mime-types", ">= 3.3", "< 4"
   s.add_dependency "oj", ">= 3.10", "< 4"
   s.add_dependency "require_all", ">= 2", "< 4"
+  s.add_dependency "rspec-expectations", "~> 3.12"
   s.add_dependency "uuid", ">= 2.3", "< 3"
 end

--- a/allure-ruby-commons/lib/allure-ruby-commons.rb
+++ b/allure-ruby-commons/lib/allure-ruby-commons.rb
@@ -225,7 +225,7 @@ module Allure
     lifecycle.update_test_step { |step| step.status = Status::PASSED }
 
     result
-  rescue StandardError => e
+  rescue StandardError, RSpec::Expectations::ExpectationNotMetError => e
     lifecycle.update_test_step do |step|
       step.status = ResultUtils.status(e)
       step.status_details = ResultUtils.status_details(e)


### PR DESCRIPTION
Fixes: https://github.com/allure-framework/allure-ruby/issues/444

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/447/merge/3569229939/index.html) for [2d749819](https://github.com/allure-framework/allure-ruby/pull/447/commits/2d7498194e15e9de02817b21bc8f4198f3a50100)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 96     | 0      | 0       | 0     | 96    | ✅     |
| allure-rspec        | 63     | 0      | 0       | 0     | 63    | ✅     |
| allure-ruby-commons | 270    | 0      | 0       | 0     | 270   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 429    | 0      | 0       | 0     | 429   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->