### PR TITLE
Correctly handle failure to load testplan.json

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,0 @@
-version: "2"
-
-plugins:
-  bundler-audit:
-    enabled: true

--- a/allure-ruby-commons/lib/allure_ruby_commons/_json_helper.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/_json_helper.rb
@@ -28,6 +28,7 @@ module Allure
       define_method(:load_json) do |json|
         Oj.load_file(json, symbol_keys: true)
       rescue Oj::ParseError
+        Allure.configuration.logger.error("Failed to parse json: #{json}")
         nil
       end
     rescue LoadError
@@ -40,6 +41,7 @@ module Allure
       define_method(:load_json) do |json|
         JSON.parse(File.read(json), symbolize_names: true)
       rescue JSON::ParserError
+        Allure.configuration.logger.error("Failed to parse json: #{json}")
         nil
       end
     end

--- a/allure-ruby-commons/lib/allure_ruby_commons/testplan.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/testplan.rb
@@ -28,13 +28,17 @@ module Allure
       #
       # @return [Array<Hash>]
       def tests
-        @tests ||= load_json(test_plan_path)&.fetch(:tests) if ENV[TESTPLAN_PATH]
+        @tests ||= load_json(test_plan_path)&.fetch(:tests) if test_plan_path
       end
 
+      # Fetch test plan path
+      #
+      # @return [<String, nil>]
       def test_plan_path
         return @test_plan_path if defined?(@test_plan_path)
 
         @test_plan_path = ENV[TESTPLAN_PATH].then do |path|
+          next unless path
           next path if File.file?(path)
 
           json = File.join(path, "testplan.json")

--- a/allure-ruby-commons/lib/allure_ruby_commons/testplan.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/testplan.rb
@@ -28,7 +28,21 @@ module Allure
       #
       # @return [Array<Hash>]
       def tests
-        @tests ||= load_json(ENV[TESTPLAN_PATH])&.fetch(:tests) if ENV[TESTPLAN_PATH]
+        @tests ||= load_json(test_plan_path)&.fetch(:tests) if ENV[TESTPLAN_PATH]
+      end
+
+      def test_plan_path
+        return @test_plan_path if defined?(@test_plan_path)
+
+        @test_plan_path = ENV[TESTPLAN_PATH].then do |path|
+          next path if File.file?(path)
+
+          json = File.join(path, "testplan.json")
+          next json if File.exist?(json)
+
+          Allure.configuration.logger.warn("'ALLURE_TESTPLAN_PATH' env var is set, but no testplan.json found!")
+          nil
+        end
       end
     end
   end

--- a/allure-ruby-commons/spec/unit/testplan_spec.rb
+++ b/allure-ruby-commons/spec/unit/testplan_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Allure::TestPlan do
+describe Allure::TestPlan, :aggregate_failures do
   let(:test_ids) { ["test case id, aka allure id"] }
   let(:test_names) { ["some unique id or selector that can be used to run particular test case"] }
 
@@ -22,10 +22,8 @@ describe Allure::TestPlan do
     let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan/correct/testplan.json" }
 
     it "correct testplan.json" do
-      aggregate_failures do
-        expect(described_class.test_ids).to eq(test_ids)
-        expect(described_class.test_names).to eq(test_names)
-      end
+      expect(described_class.test_ids).to eq(test_ids)
+      expect(described_class.test_names).to eq(test_names)
     end
   end
 
@@ -33,21 +31,26 @@ describe Allure::TestPlan do
     let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan/malformed/testplan.json" }
 
     it "malformed testplan.json" do
-      aggregate_failures do
-        expect(described_class.test_ids).to eq(nil)
-        expect(described_class.test_names).to eq(nil)
-      end
+      expect(described_class.test_ids).to eq(nil)
+      expect(described_class.test_names).to eq(nil)
     end
   end
 
   context "handles" do
-    let(:path) { nil }
+    let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan" }
 
-    it "missing testplan.json" do
-      aggregate_failures do
-        expect(described_class.test_ids).to eq(nil)
-        expect(described_class.test_names).to eq(nil)
-      end
+    it "incorrect test plan directory" do
+      expect(described_class.test_ids).to eq(nil)
+      expect(described_class.test_names).to eq(nil)
+    end
+  end
+
+  context "handles" do
+    let(:path) { "#{Dir.pwd}/spec/fixtures/test_plan/correct" }
+
+    it "testplan.json directory" do
+      expect(described_class.test_ids).to eq(test_ids)
+      expect(described_class.test_names).to eq(test_names)
     end
   end
 end

--- a/allure-ruby-commons/spec/unit/testplan_spec.rb
+++ b/allure-ruby-commons/spec/unit/testplan_spec.rb
@@ -8,6 +8,10 @@ describe Allure::TestPlan do
     described_class.instance_variable_set(:@tests, nil)
     described_class.instance_variable_set(:@test_ids, nil)
     described_class.instance_variable_set(:@test_names, nil)
+
+    :@test_plan_path.tap do |var|
+      described_class.send(:remove_instance_variable, var) if described_class.instance_variable_defined?(var)
+    end
   end
 
   around do |example|


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/495/merge/5118631383/index.html) for [dc343cf5](https://github.com/allure-framework/allure-ruby/pull/495/commits/dc343cf5f6f8dfda601ed71d7e706b15e3d9752d)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 192    | 0      | 0       | 0     | 192   | ✅     |
| allure-rspec        | 126    | 0      | 0       | 0     | 126   | ✅     |
| allure-ruby-commons | 546    | 0      | 0       | 0     | 546   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 864    | 0      | 0       | 0     | 864   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->