### PR TITLE
Calculate history id based on all test case parameters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,8 @@ jobs:
         uses: paambaati/codeclimate-action@v4.0.0
         env:
           CC_TEST_REPORTER_ID: be263ef9412dc65a7aa8dfb6e8162d5c7cfb3307fae0a444cde9dd6ca6f52848
-          ALLURE_ENVIRONMENT: ruby-${{ matrix.ruby }}-oj-${{ matrix.oj }}
+          WITH_OJ_GEM: ${{ matrix.oj }}
+          RUBY_VERSION: ${{ matrix.ruby }}
         with:
           coverageCommand: bundle exec rake test:coverage
           coverageLocations: coverage/coverage.json:simplecov

--- a/allure-cucumber/spec/spec_helper.rb
+++ b/allure-cucumber/spec/spec_helper.rb
@@ -17,6 +17,8 @@ end
 RSpec.configure do |config|
   config.before do |example|
     example.epic("allure-cucumber")
+    example.parameter("ruby", ENV["RUBY_VERSION"])
+    example.parameter("oj", ENV["WITH_OJ_GEM"])
   end
 end
 

--- a/allure-rspec/spec/spec_helper.rb
+++ b/allure-rspec/spec/spec_helper.rb
@@ -16,6 +16,8 @@ end
 RSpec.configure do |config|
   config.before do |example|
     example.epic("allure-rspec")
+    example.parameter("ruby", ENV["RUBY_VERSION"])
+    example.parameter("oj", ENV["WITH_OJ_GEM"])
   end
 end
 

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/01_jsonable.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/01_jsonable.rb
@@ -6,9 +6,9 @@ module Allure
     # Return object hash represantation
     # @return [Hash]
     def to_hash
-      instance_variables.each_with_object({}) do |var, map|
-        key = camelcase(var.to_s.delete_prefix("@"))
-        value = instance_variable_get(var)
+      json_attributes.each_with_object({}) do |attribute, map|
+        key = camelcase(attribute)
+        value = send(attribute) # fetch via reader for dynamically generated attributes
         map[key] = value unless value.nil?
       end
     end
@@ -33,7 +33,7 @@ module Allure
     # Object state
     # @return [Array]
     def state
-      instance_variables.map { |var| instance_variable_get(var) }
+      json_attributes.map { |attribute| send(attribute) }
     end
 
     private
@@ -44,6 +44,13 @@ module Allure
     def camelcase(str)
       str = str.gsub(/(?:_+)([a-z])/) { Regexp.last_match(1).upcase }
       str.gsub(/(\A|\s)([A-Z])/) { Regexp.last_match(1) + Regexp.last_match(2).downcase }
+    end
+
+    # Json attribute names
+    #
+    # @return [Array<String>]
+    def json_attributes
+      @json_attributes ||= instance_variables.map { |attribute| attribute.to_s.delete_prefix("@") }
     end
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/category.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/category.rb
@@ -15,5 +15,7 @@ module Allure
       @message_regex = message_regex
       @trace_regex = trace_regex
     end
+
+    attr_reader :name, :matched_statuses, :message_regex, :trace_regex
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
@@ -24,7 +24,7 @@ module Allure
 
       @name = options[:name]
       @uuid = uuid
-      @history_id = Digest::MD5.hexdigest("#{history_id}#{environment}")
+      @history_id = history_id
       @full_name = options[:full_name] || "Unnamed"
       @labels = options[:labels] || []
       @links = options[:links] || []
@@ -32,9 +32,26 @@ module Allure
     end
 
     attr_accessor :uuid,
-                  :history_id,
                   :full_name,
                   :labels,
                   :links
+
+    attr_writer :history_id
+
+    # History id
+    #
+    # @return [String]
+    def history_id
+      Digest::MD5.hexdigest("#{@history_id}#{parameters_string}")
+    end
+
+    private
+
+    # All parameters string
+    #
+    # @return [String]
+    def parameters_string
+      parameters.map { |p| "#{p.name}=#{p.value}" }.join(";")
+    end
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/test_result_container.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/test_result_container.rb
@@ -14,6 +14,15 @@ module Allure
       @links = []
     end
 
-    attr_accessor :uuid, :name, :description, :description_html, :start, :stop, :children, :befores, :afters, :links
+    attr_accessor :uuid,
+                  :name,
+                  :description,
+                  :description_html,
+                  :start,
+                  :stop,
+                  :children,
+                  :befores,
+                  :afters,
+                  :links
   end
 end

--- a/allure-ruby-commons/spec/spec_helper.rb
+++ b/allure-ruby-commons/spec/spec_helper.rb
@@ -17,6 +17,8 @@ end
 RSpec.configure do |config|
   config.before do |example|
     example.epic("allure-ruby-commons")
+    example.parameter("ruby", ENV["RUBY_VERSION"])
+    example.parameter("oj", ENV["WITH_OJ_GEM"])
   end
 end
 


### PR DESCRIPTION
Take in to account all test case parameters when generating history id to make sure it's unique based on parameters set for test case.

Fixes: https://github.com/allure-framework/allure-ruby/issues/494

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/498/merge/5192221103/index.html) for [c3d8c712](https://github.com/allure-framework/allure-ruby/pull/498/commits/c3d8c7122509004551f02e561fe1deaec9dc00c4)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 192    | 0      | 0       | 0     | 192   | ✅     |
| allure-rspec        | 126    | 0      | 0       | 0     | 126   | ✅     |
| allure-ruby-commons | 546    | 0      | 0       | 0     | 546   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 864    | 0      | 0       | 0     | 864   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->