### PR TITLE
Drop ruby 2.7 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
     - bin/**/*

--- a/allure-cucumber/allure-cucumber.gemspec
+++ b/allure-cucumber/allure-cucumber.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "rubygems_mfa_required" => "false"
   }
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.license = "Apache-2.0"
 

--- a/allure-rspec/allure-rspec.gemspec
+++ b/allure-rspec/allure-rspec.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "rubygems_mfa_required" => "false"
   }
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.license = "Apache-2.0"
 

--- a/allure-ruby-commons/allure-ruby-commons.gemspec
+++ b/allure-ruby-commons/allure-ruby-commons.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "rubygems_mfa_required" => "false"
   }
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.license = "Apache-2.0"
 


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/499/merge/5208875839/index.html) for [e15efa4f](https://github.com/allure-framework/allure-ruby/pull/499/commits/e15efa4facdc8cfed8cd66c9407020120f07f09e)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 192    | 0      | 0       | 0     | 192   | ✅     |
| allure-rspec        | 126    | 0      | 0       | 0     | 126   | ✅     |
| allure-ruby-commons | 546    | 0      | 0       | 0     | 546   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 864    | 0      | 0       | 0     | 864   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->