### PR TITLE
Correctly handle all common configuration options

### DIFF
--- a/allure-cucumber/lib/allure_cucumber/config.rb
+++ b/allure-cucumber/lib/allure_cucumber/config.rb
@@ -21,7 +21,6 @@ module AllureCucumber
   #   @return [String]
   class CucumberConfig
     include Singleton
-    extend Forwardable
 
     # @return [String] default tms tag prefix
     DEFAULT_TMS_PREFIX = "TMS:"
@@ -35,26 +34,6 @@ module AllureCucumber
     DEFAULT_FEATURE_PREFIX = "FEATURE:"
     # @return [String] default story tag prefix
     DEFAULT_STORY_PREFIX = "STORY:"
-
-    def_delegators :@allure_config,
-                   :clean_results_directory,
-                   :clean_results_directory=,
-                   :link_issue_pattern,
-                   :link_issue_pattern=,
-                   :link_tms_pattern,
-                   :link_tms_pattern=,
-                   :logging_level,
-                   :logging_level=,
-                   :logger,
-                   :logger=,
-                   :results_directory,
-                   :results_directory=,
-                   :environment,
-                   :environment=,
-                   :environment_properties,
-                   :environment_properties=,
-                   :categories,
-                   :categories=
 
     attr_writer :tms_prefix,
                 :issue_prefix,
@@ -95,6 +74,14 @@ module AllureCucumber
     # @return [String]
     def story_prefix
       @story_prefix || DEFAULT_STORY_PREFIX
+    end
+
+    def method_missing(method, ...)
+      @allure_config.respond_to?(method) ? @allure_config.send(method, ...) : super
+    end
+
+    def respond_to_missing?(method, include_private = false)
+      @allure_config.respond_to?(method, include_private) || super
     end
   end
 end

--- a/allure-cucumber/spec/unit/allure_cucumber_spec.rb
+++ b/allure-cucumber/spec/unit/allure_cucumber_spec.rb
@@ -1,11 +1,30 @@
 # frozen_string_literal: true
 
 describe AllureCucumber do
+  let(:cucumber_config) { AllureCucumber::CucumberConfig.send(:new) }
+
+  before do
+    allow(Allure::Config).to receive(:instance).and_return(Allure::Config.send(:new))
+    allow(AllureCucumber::CucumberConfig).to receive(:instance).and_return(cucumber_config)
+  end
+
   it "returns cucumber configuration" do
     expect(AllureCucumber.configuration).to be_a(AllureCucumber::CucumberConfig)
   end
 
   it "yields cucumber configuration" do
-    expect { |b| AllureCucumber.configure(&b) }.to yield_with_args(AllureCucumber::CucumberConfig.instance)
+    expect { |b| AllureCucumber.configure(&b) }.to yield_with_args(cucumber_config)
+  end
+
+  it "supports common configuration options" do
+    AllureCucumber.configure { |config| config.failure_exception = StandardError }
+
+    expect(AllureCucumber.configuration.failure_exception).to eq(StandardError)
+  end
+
+  it "supports cucumber specific configuration options" do
+    AllureCucumber.configure { |config| config.tms_prefix = "TMS" }
+
+    expect(AllureCucumber.configuration.tms_prefix).to eq("TMS")
   end
 end

--- a/allure-rspec/lib/allure_rspec/config.rb
+++ b/allure-rspec/lib/allure_rspec/config.rb
@@ -21,7 +21,6 @@ module AllureRspec
   #   @return [String]
   class RspecConfig
     include Singleton
-    extend Forwardable
 
     # @return [Symbol] default tms tag
     DEFAULT_TMS_TAG = :tms
@@ -35,26 +34,6 @@ module AllureRspec
     DEFAULT_FEATURE_TAG = :feature
     # @return [Symbol] default story tag
     DEFAULT_STORY_TAG = :story
-
-    def_delegators :@allure_config,
-                   :clean_results_directory,
-                   :clean_results_directory=,
-                   :link_issue_pattern,
-                   :link_issue_pattern=,
-                   :link_tms_pattern,
-                   :link_tms_pattern=,
-                   :logging_level,
-                   :logging_level=,
-                   :logger,
-                   :logger=,
-                   :results_directory,
-                   :results_directory=,
-                   :environment,
-                   :environment=,
-                   :environment_properties,
-                   :environment_properties=,
-                   :categories,
-                   :categories=
 
     def initialize
       @allure_config = Allure.configuration
@@ -101,6 +80,14 @@ module AllureRspec
     # @return [Array]
     def ignored_tags
       @ignored_tags || []
+    end
+
+    def method_missing(method, ...)
+      @allure_config.respond_to?(method) ? @allure_config.send(method, ...) : super
+    end
+
+    def respond_to_missing?(method, include_private = false)
+      @allure_config.respond_to?(method, include_private) || super
     end
   end
 end

--- a/allure-rspec/spec/unit/allure_rspec_spec.rb
+++ b/allure-rspec/spec/unit/allure_rspec_spec.rb
@@ -1,11 +1,30 @@
 # frozen_string_literal: true
 
 describe AllureRspec do
+  let(:rspec_config) { AllureRspec::RspecConfig.send(:new) }
+
+  before do
+    allow(Allure::Config).to receive(:instance).and_return(Allure::Config.send(:new))
+    allow(AllureRspec::RspecConfig).to receive(:instance).and_return(rspec_config)
+  end
+
   it "returns rspec configuration" do
     expect(AllureRspec.configuration).to be_a(AllureRspec::RspecConfig)
   end
 
   it "yields rspec configuration" do
-    expect { |b| AllureRspec.configure(&b) }.to yield_with_args(AllureRspec::RspecConfig.instance)
+    expect { |b| AllureRspec.configure(&b) }.to yield_with_args(rspec_config)
+  end
+
+  it "supports common configuration options" do
+    AllureRspec.configure { |config| config.failure_exception = StandardError }
+
+    expect(AllureRspec.configuration.failure_exception).to eq(StandardError)
+  end
+
+  it "supports rspec specific configuration options" do
+    AllureRspec.configure { |config| config.tms_tag = "TMS" }
+
+    expect(AllureRspec.configuration.tms_tag).to eq("TMS")
   end
 end


### PR DESCRIPTION
Closes https://github.com/allure-framework/allure-ruby/issues/533

<!-- allure -->
---
# Allure Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/534/merge/8050111673/index.html) for [8e1f7a73](https://github.com/allure-framework/allure-ruby/pull/534/commits/8e1f7a73420095ee0a759beac8c0d4018568c9e2)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 272    | 0      | 0       | 0     | 272   | ✅     |
| allure-rspec        | 184    | 0      | 0       | 0     | 184   | ✅     |
| allure-ruby-commons | 728    | 0      | 0       | 0     | 728   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 1184   | 0      | 0       | 0     | 1184  | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->