### PR TITLE
Correctly detect location when shared example is used

### DIFF
--- a/allure-rspec/lib/allure_rspec/formatter.rb
+++ b/allure-rspec/lib/allure_rspec/formatter.rb
@@ -104,8 +104,8 @@ module AllureRspec
 
       Allure::TestResult.new(
         name: example.description,
-        description: "Location - #{strip_relative(example.location)}",
-        description_html: "Location - #{strip_relative(example.location)}",
+        description: "Location - #{strip_relative(parser.location)}",
+        description_html: "Location - #{strip_relative(parser.location)}",
         history_id: example.id,
         full_name: example.full_description,
         labels: parser.labels,

--- a/allure-rspec/lib/allure_rspec/metadata_parser.rb
+++ b/allure-rspec/lib/allure_rspec/metadata_parser.rb
@@ -31,7 +31,7 @@ module AllureRspec
     # Metadata parser instance
     #
     # @param [RSpec::Core::Example] example
-    # @param [AllureRspec::RspecConfig] config <description>
+    # @param [AllureRspec::RspecConfig] config
     def initialize(example, config)
       @example = example
       @config = config
@@ -65,6 +65,21 @@ module AllureRspec
         muted: !metadata[:muted].nil?,
         known: !metadata[:known].nil?
       )
+    end
+
+    # Example location
+    #
+    # @return [String]
+    def location
+      file = example
+             .metadata
+             .fetch(:shared_group_inclusion_backtrace)
+             .last
+             &.formatted_inclusion_location
+
+      return example.location unless file
+
+      file
     end
 
     private

--- a/allure-rspec/spec/unit/formatter_example_started_spec.rb
+++ b/allure-rspec/spec/unit/formatter_example_started_spec.rb
@@ -51,6 +51,28 @@ describe "example_started" do
         end
       end
     end
+
+    context "with shared example" do
+      it "correctly detects spec location" do
+        run_rspec(<<~SPEC)
+          shared_examples "shared" do
+            it "#{spec}" do |e|
+              e.step(name: "test body")
+            end
+          end
+
+          describe "#{suite}" do
+            it_behaves_like "shared"
+          end
+        SPEC
+
+        expect(lifecycle).to have_received(:start_test_case).once do |arg|
+          aggregate_failures "Should have correct args" do
+            expect(arg.description).to eq("Location - #{test_tmp_dir}/spec/test_spec.rb:8")
+          end
+        end
+      end
+    end
   end
 
   context "allure environment" do


### PR DESCRIPTION
Set location to where spec is located rather than location of where shared_example is defined.

<!-- allure -->
---
# Allure Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/539/merge/8330896158/index.html) for [751bc356](https://github.com/allure-framework/allure-ruby/pull/539/commits/751bc356eeece50d8c5cacf468c70009b20feec3)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 272    | 0      | 0       | 0     | 272   | ✅     |
| allure-rspec        | 192    | 0      | 0       | 0     | 192   | ✅     |
| allure-ruby-commons | 728    | 0      | 0       | 0     | 728   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 1192   | 0      | 0       | 0     | 1192  | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->