### PR TITLE
Revert "Fixing category page 404 error due to exception message being passed as nil"

### DIFF
--- a/allure-rspec/spec/unit/formatter_example_finished_spec.rb
+++ b/allure-rspec/spec/unit/formatter_example_finished_spec.rb
@@ -36,7 +36,7 @@ describe "example_finished" do
       aggregate_failures "Should update correct test case parameters" do
         expect(@test_case.stage).to eq(Allure::Stage::FINISHED)
         expect(@test_case.status).to eq(Allure::Status::PASSED)
-        expect(@test_case.status_details).to eq(Allure::StatusDetails.new(message: "NilClass"))
+        expect(@test_case.status_details).to eq(Allure::StatusDetails.new)
       end
     end
   end

--- a/allure-ruby-commons/lib/allure_ruby_commons/result_utils.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/result_utils.rb
@@ -159,7 +159,7 @@ module Allure
       # @param [Exception] exception
       # @return [Allure::StatusDetails]
       def status_details(exception)
-        StatusDetails.new(message: exception&.message || exception.class.name, trace: exception&.backtrace&.join("\n"))
+        StatusDetails.new(message: exception&.message, trace: exception&.backtrace&.join("\n"))
       end
 
       # Allure attachment object

--- a/allure-ruby-commons/spec/unit/result_utils_spec.rb
+++ b/allure-ruby-commons/spec/unit/result_utils_spec.rb
@@ -93,10 +93,4 @@ describe Allure::ResultUtils do
     expect(status_details.message).to include("Got 2 failures from failure aggregation block")
     expect(status_details.trace).not_to be_empty
   end
-
-  it "returns status details for nill class error" do
-    status_details = Allure::ResultUtils.status_details(nil)
-    expect(status_details.message).to eq("NilClass")
-    expect(status_details.instance_variable_defined?(:@trace)).to be_truthy
-  end
 end


### PR DESCRIPTION
Reverts allure-framework/allure-ruby#546