### PR TITLE
Fix keyword arguments not being passed when using step annotation

### DIFF
--- a/allure-ruby-commons/lib/allure_ruby_commons/step_annotation.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/step_annotation.rb
@@ -20,8 +20,8 @@ module AllureStepAnnotation
     step_name = @allure_step.empty? ? method_name.to_s : @allure_step
     @allure_step = nil
 
-    define_singleton_method(method_name) do |*args, &block|
-      Allure.run_step(step_name) { original_method.call(*args, &block) }
+    define_singleton_method(method_name) do |*args, **kwargs, &block|
+      Allure.run_step(step_name) { original_method.call(*args, **kwargs, &block) }
     end
   end
 
@@ -32,8 +32,8 @@ module AllureStepAnnotation
     step_name = @allure_step.empty? ? method_name.to_s : @allure_step
     @allure_step = nil
 
-    define_method(method_name) do |*args, &block|
-      Allure.run_step(step_name) { original_method.bind_call(self, *args, &block) }
+    define_method(method_name) do |*args, **kwargs, &block|
+      Allure.run_step(step_name) { original_method.bind_call(self, *args, **kwargs, &block) }
     end
   end
 end

--- a/allure-ruby-commons/spec/unit/step_annotation_spec.rb
+++ b/allure-ruby-commons/spec/unit/step_annotation_spec.rb
@@ -4,37 +4,40 @@ class TestHelper
   extend AllureStepAnnotation
 
   step("Singleton step")
-  def self.class_method; end
+  def self.class_method(arg)
+    "class_method: #{arg}"
+  end
 
   step("Standard step")
-  def standard_method; end
+  def standard_method(keyword_arg:)
+    "standard_method: #{keyword_arg}"
+  end
 
   step
-  def default_name_method; end
+  def default_name_method
+    "default_name"
+  end
 end
 
 describe AllureStepAnnotation do
   let(:test_helper) { TestHelper.new }
 
   before do
-    allow(Allure).to receive(:run_step)
+    allow(Allure).to receive(:run_step).and_yield
   end
 
   it "Creates step from singleton method" do
-    TestHelper.class_method
-
+    expect(TestHelper.class_method("test")).to eq("class_method: test")
     expect(Allure).to have_received(:run_step).with("Singleton step")
   end
 
   it "Creates step from instance method" do
-    test_helper.standard_method
-
+    expect(test_helper.standard_method(keyword_arg: "value")).to eq("standard_method: value")
     expect(Allure).to have_received(:run_step).with("Standard step")
   end
 
   it "Creates step with default method name" do
-    test_helper.default_name_method
-
+    expect(test_helper.default_name_method).to eq("default_name")
     expect(Allure).to have_received(:run_step).with("default_name_method")
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/allure-framework/allure-ruby/issues/549

<!-- allure -->
---
# Allure Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](https://storage.googleapis.com/allure-test-reports/allure-ruby/refs/pull/550/merge/8973356773/index.html) for [996dbacb](https://github.com/allure-framework/allure-ruby/pull/550/commits/996dbacb8b01292ead9c0b427da3df33d24d444a)
```markdown
+--------------------------------------------------------------------------+
|                            behaviors summary                             |
+---------------------+--------+--------+---------+-------+-------+--------+
|                     | passed | failed | skipped | flaky | total | result |
+---------------------+--------+--------+---------+-------+-------+--------+
| allure-cucumber     | 272    | 0      | 0       | 0     | 272   | ✅     |
| allure-rspec        | 192    | 0      | 0       | 0     | 192   | ✅     |
| allure-ruby-commons | 728    | 0      | 0       | 0     | 728   | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
| Total               | 1192   | 0      | 0       | 0     | 1192  | ✅     |
+---------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->