### PR TITLE
Remove uuid dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,6 @@ updates:
       dependency-type: indirect
     - dependency-name: require_all
       dependency-type: indirect
-    - dependency-name: uuid
-      dependency-type: indirect
 - package-ecosystem: bundler
   directory: /allure-rspec
   schedule:

--- a/allure-ruby-commons/allure-ruby-commons.gemspec
+++ b/allure-ruby-commons/allure-ruby-commons.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |s|
   s.add_dependency "mime-types", ">= 3.3", "< 4"
   s.add_dependency "require_all", ">= 2", "< 4"
   s.add_dependency "rspec-expectations", "~> 3.12"
-  s.add_dependency "uuid", ">= 2.3", "< 3"
 end

--- a/allure-ruby-commons/lib/allure-ruby-commons.rb
+++ b/allure-ruby-commons/lib/allure-ruby-commons.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "require_all"
-require "uuid"
+require "securerandom"
 
 require_rel "allure_ruby_commons/**/*rb"
 

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
@@ -19,7 +19,7 @@ module Allure
     # @option options [Array<Allure::Link>] :links ([])
     # @option options [Array<Allure::Attachment>] :attachments ([])
     # @option options [Array<Allure::Parameter>] :parameters ([])
-    def initialize(uuid: UUID.generate, history_id: UUID.generate, environment: nil, **options)
+    def initialize(uuid: SecureRandom.uuid, history_id: SecureRandom.uuid, environment: nil, **options)
       super
 
       @name = options[:name]

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/test_result_container.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/test_result_container.rb
@@ -3,7 +3,7 @@
 module Allure
   # Allure model step result container
   class TestResultContainer < JSONable
-    def initialize(uuid: UUID.generate, name: "Unnamed")
+    def initialize(uuid: SecureRandom.uuid, name: "Unnamed")
       super()
 
       @uuid = uuid

--- a/allure-ruby-commons/lib/allure_ruby_commons/result_utils.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/result_utils.rb
@@ -168,7 +168,7 @@ module Allure
       # @return [Allure::Attachment]
       def prepare_attachment(name, type)
         extension = ContentType.to_extension(type) || return
-        file_name = "#{UUID.generate}-attachment.#{extension}"
+        file_name = "#{SecureRandom.uuid}-attachment.#{extension}"
         Attachment.new(name: name, source: file_name, type: type)
       end
 

--- a/allure-ruby-commons/spec/unit/file_writer_spec.rb
+++ b/allure-ruby-commons/spec/unit/file_writer_spec.rb
@@ -29,7 +29,7 @@ describe Allure::FileWriter do
     attachment = Allure::Attachment.new(
       name: "Test attachment",
       type: Allure::ContentType::TXT,
-      source: "#{UUID.generate}-attachment.txt"
+      source: "#{SecureRandom.uuid}-attachment.txt"
     )
     attachment_file = File.join(results_dir, attachment.source)
     file_writer.write_attachment("Test attachment", attachment)
@@ -41,7 +41,7 @@ describe Allure::FileWriter do
     attachment = Allure::Attachment.new(
       name: "Test attachment",
       type: Allure::ContentType::PNG,
-      source: "#{UUID.generate}-attachment.png"
+      source: "#{SecureRandom.uuid}-attachment.png"
     )
     source = File.new(File.join(Dir.pwd, "spec", "fixtures", "ruby-logo.png"))
     attachment_file = File.join(results_dir, attachment.source)


### PR DESCRIPTION
## Why

The `uuid` gem is archived on GitHub since Jan 1, 2024: https://github.com/assaf/uuid

Although one might consider it feature complete and no longer require any updates (in fact, the last update was made 5 years ago), I would still consider it a risk. Its transitive dependencies `macaddr` and `systemu` were updated in 2019 and 2015 respectively.

The change removes 3 dependencies: `uuid` » `macaddr` » `systemu`.

## How

Ruby already has a way to generate UUIDs via `SecureRandom`. It is v4 (compared to v1 implemented by the `uuid` gem), but for Allure purposes it should make no difference. Another option is PRNG version implemented in `Random#uuid_v4` and `Random#uuid_v7`, but it requires an instance of PRNG, and so more code changes.