### PR TITLE
Show skipped test reason in report

### DIFF
--- a/allure-cucumber/lib/allure_cucumber/models/cucumber_model.rb
+++ b/allure-cucumber/lib/allure_cucumber/models/cucumber_model.rb
@@ -60,7 +60,7 @@ module AllureCucumber
     # @return [Hash<Symbol, String>]
     def failure_details(result)
       return { message: result.exception.message, trace: result.exception.backtrace.join("\n") } if result.failed?
-      return { message: result.message, trace: result.backtrace.join("\n") } if result.undefined?
+      return { message: result.message, trace: result.backtrace.join("\n") } if result.undefined? || result.skipped?
 
       {}
     end

--- a/allure-cucumber/spec/cucumber_helper.rb
+++ b/allure-cucumber/spec/cucumber_helper.rb
@@ -26,6 +26,10 @@ class CucumberHelper
 
     AfterStep("@after_step") do
     end
+
+    Before("@skipped") do
+      skip_this_scenario("because reasons")
+    end
   RUBY
 
   STEPS = <<~RUBY

--- a/allure-cucumber/spec/unit/formatter_test_case_stopped_spec.rb
+++ b/allure-cucumber/spec/unit/formatter_test_case_stopped_spec.rb
@@ -86,4 +86,29 @@ describe "on_test_case_finished" do
       end
     end
   end
+
+  it "correctly updates skipped test case" do
+    run_cucumber_cli(<<~FEATURE)
+      Feature: Simple feature
+
+      @skipped
+      Scenario: Add a to b
+        Simple scenario description
+        Given a is 5
+        And b is 10
+        When I add a to b
+        Then step fails with simple exception
+        And this step shoud be skipped
+    FEATURE
+
+    expect(lifecycle).to have_received(:update_test_case).with(no_args) do |&arg|
+      arg.call(@test_case)
+      aggregate_failures "Should update correct test case parameters" do
+        expect(@test_case.stage).to eq(Allure::Stage::FINISHED)
+        expect(@test_case.status).to eq(Allure::Status::SKIPPED)
+        expect(@test_case.status_details.message).to eq("because reasons")
+        expect(@test_case.status_details.trace).not_to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hello ! :) 

Cucumber allows to skip scenario using **skip_this_scenario** method : https://www.rubydoc.info/gems/cucumber/Cucumber/Glue/ProtoWorld#skip_this_scenario-instance_method

This method also accepts optional string argument to specify more info about why this particular scenario is skipped.

Currently Allure report does not show this reason, but it would be great if it could. (particularly great if test scenario skipping logic becomes complex over time)

I hacked around a bit and managed to make it work using monkeypatch. I would like to include these changes also to upstream.

TODO:

* handle failure details for skipped scenario same way as for failed
* add test for skipped scenario
