### PR TITLE
Add excluded and mode attributes to Parameter

### DIFF
--- a/allure-ruby-commons/lib/allure-ruby-commons.rb
+++ b/allure-ruby-commons/lib/allure-ruby-commons.rb
@@ -118,7 +118,7 @@ module Allure
   # @param [String] name
   # @param [String] value
   # @return [void]
-  def parameter(name, value, excluded: false, mode: "default")
+  def parameter(name, value, excluded: false, mode: Allure::Parameter::DEFAULT)
     lifecycle.update_test_case do |test_case|
       test_case.parameters.push(Parameter.new(name, value, excluded: excluded, mode: mode))
     end
@@ -239,7 +239,7 @@ module Allure
   # @param [String] name
   # @param [String] value
   # @return [void]
-  def step_parameter(name, value, excluded: false, mode: "default")
+  def step_parameter(name, value, excluded: false, mode: Allure::Parameter::DEFAULT)
     lifecycle.update_test_step do |step|
       step.parameters.push(Parameter.new(name, value, excluded: excluded, mode: mode))
     end

--- a/allure-ruby-commons/lib/allure-ruby-commons.rb
+++ b/allure-ruby-commons/lib/allure-ruby-commons.rb
@@ -118,9 +118,9 @@ module Allure
   # @param [String] name
   # @param [String] value
   # @return [void]
-  def parameter(name, value)
+  def parameter(name, value, excluded: false, mode: 'default')
     lifecycle.update_test_case do |test_case|
-      test_case.parameters.push(Parameter.new(name, value))
+      test_case.parameters.push(Parameter.new(name, value, excluded: excluded, mode: mode))
     end
   end
 
@@ -239,9 +239,9 @@ module Allure
   # @param [String] name
   # @param [String] value
   # @return [void]
-  def step_parameter(name, value)
+  def step_parameter(name, value, excluded: false, mode: 'default')
     lifecycle.update_test_step do |step|
-      step.parameters.push(Parameter.new(name, value))
+      step.parameters.push(Parameter.new(name, value, excluded: excluded, mode: mode))
     end
   end
 end

--- a/allure-ruby-commons/lib/allure-ruby-commons.rb
+++ b/allure-ruby-commons/lib/allure-ruby-commons.rb
@@ -118,7 +118,7 @@ module Allure
   # @param [String] name
   # @param [String] value
   # @return [void]
-  def parameter(name, value, excluded: false, mode: 'default')
+  def parameter(name, value, excluded: false, mode: "default")
     lifecycle.update_test_case do |test_case|
       test_case.parameters.push(Parameter.new(name, value, excluded: excluded, mode: mode))
     end
@@ -239,7 +239,7 @@ module Allure
   # @param [String] name
   # @param [String] value
   # @return [void]
-  def step_parameter(name, value, excluded: false, mode: 'default')
+  def step_parameter(name, value, excluded: false, mode: "default")
     lifecycle.update_test_step do |step|
       step.parameters.push(Parameter.new(name, value, excluded: excluded, mode: mode))
     end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -3,13 +3,15 @@
 module Allure
   # Allure model parameter object
   class Parameter < JSONable
-    def initialize(name, value)
+    def initialize(name, value, excluded: false, mode: 'default')
       super()
 
       @name = name
       @value = value
+      @excluded = excluded
+      @mode = mode
     end
 
-    attr_reader :name, :value
+    attr_reader :name, :value, :excluded, :mode
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -3,15 +3,25 @@
 module Allure
   # Allure model parameter object
   class Parameter < JSONable
-    def initialize(name, value, excluded: false, mode: 'default')
+    MODES = %w[default masked hidden].freeze
+    def initialize(name, value, excluded: false, mode: "default")
       super()
 
       @name = name
       @value = value
       @excluded = excluded
+      validate_mode!(mode)
       @mode = mode
     end
 
     attr_reader :name, :value, :excluded, :mode
+
+    private
+
+    def validate_mode!(mode)
+      return if MODES.include?(mode)
+
+      Allure.configuration.logger.error "Parameter mode '#{mode}' is invalid. Valid modes are: #{MODES.join(', ')}"
+    end
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -3,7 +3,10 @@
 module Allure
   # Allure model parameter object
   class Parameter < JSONable
-    MODES = %w[default masked hidden].freeze
+    DEFAULT = "default".freeze
+    MASKED = "masked".freeze
+    HIDDEN = "hidden".freeze
+
     def initialize(name, value, excluded: false, mode: DEFAULT)
       super()
 

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -3,9 +3,9 @@
 module Allure
   # Allure model parameter object
   class Parameter < JSONable
-    DEFAULT = "default".freeze
-    MASKED = "masked".freeze
-    HIDDEN = "hidden".freeze
+    DEFAULT = "default"
+    MASKED = "masked"
+    HIDDEN = "hidden"
 
     def initialize(name, value, excluded: false, mode: DEFAULT)
       super()

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -13,8 +13,7 @@ module Allure
       @name = name
       @value = value
       @excluded = excluded
-      validate_mode!(mode)
-      @mode = mode
+      @mode = validate_mode!(mode)
     end
 
     attr_reader :name, :value, :excluded, :mode

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -23,9 +23,10 @@ module Allure
 
     def validate_mode!(mode)
       modes = [DEFAULT, MASKED, HIDDEN]
-      return if modes.include?(mode)
+      return mode if modes.include?(mode)
 
       Allure.configuration.logger.error "Parameter mode '#{mode}' is invalid. Valid modes are: #{modes.join(', ')}"
+      DEFAULT
     end
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -19,9 +19,10 @@ module Allure
     private
 
     def validate_mode!(mode)
-      return if MODES.include?(mode)
+      modes = [DEFAULT, MASKED, HIDDEN]
+      return if modes.include?(mode)
 
-      Allure.configuration.logger.error "Parameter mode '#{mode}' is invalid. Valid modes are: #{MODES.join(', ')}"
+      Allure.configuration.logger.error "Parameter mode '#{mode}' is invalid. Valid modes are: #{modes.join(', ')}"
     end
   end
 end

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/parameter.rb
@@ -4,7 +4,7 @@ module Allure
   # Allure model parameter object
   class Parameter < JSONable
     MODES = %w[default masked hidden].freeze
-    def initialize(name, value, excluded: false, mode: "default")
+    def initialize(name, value, excluded: false, mode: DEFAULT)
       super()
 
       @name = name

--- a/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
+++ b/allure-ruby-commons/lib/allure_ruby_commons/model/test_result.rb
@@ -51,7 +51,7 @@ module Allure
     #
     # @return [String]
     def parameters_string
-      parameters.map { |p| "#{p.name}=#{p.value}" }.join(";")
+      parameters.reject(&:excluded).map { |p| "#{p.name}=#{p.value}" }.join(";")
     end
   end
 end

--- a/allure-ruby-commons/spec/unit/allure_spec.rb
+++ b/allure-ruby-commons/spec/unit/allure_spec.rb
@@ -181,10 +181,11 @@ describe Allure do
       allure.run_step("New step") do
         allure.step_parameter("name", "value", excluded: true, mode: "jiberish")
       end
-      
+
       msg = "Parameter mode 'jiberish' is invalid. Valid modes are: #{modes.join(', ')}"
       expect(Allure.configuration.logger).to have_received(:error).with(msg)
-      expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", Allure::Parameter::DEFAULT))
+      parameter = Allure::Parameter.new("name", "value", mode: Allure::Parameter::DEFAULT, excluded: true)
+      expect(last_step.parameters.last).to eq(parameter)
     end
   end
 

--- a/allure-ruby-commons/spec/unit/allure_spec.rb
+++ b/allure-ruby-commons/spec/unit/allure_spec.rb
@@ -172,13 +172,17 @@ describe Allure do
       expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: Allure::Parameter::HIDDEN))
     end
 
-    it "invalid parameter mode" do
+    it "uses default mode when invalid mode parameter is set" do
       modes = [Allure::Parameter::DEFAULT, Allure::Parameter::MASKED, Allure::Parameter::HIDDEN]
-      msg = "Parameter mode 'jiberish' is invalid. Valid modes are: #{modes.join(', ')}"
-      expect(Allure.configuration.logger).to receive(:error).with(msg)
+      allow(Allure.configuration.logger).to receive(:error)
+
       allure.run_step("New step") do
         allure.step_parameter("name", "value", excluded: true, mode: "jiberish")
       end
+      
+      msg = "Parameter mode 'jiberish' is invalid. Valid modes are: #{modes.join(', ')}"
+      expect(Allure.configuration.logger).to have_received(:error).with(msg)
+      expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", Allure::Parameter::DEFAULT))
     end
   end
 

--- a/allure-ruby-commons/spec/unit/allure_spec.rb
+++ b/allure-ruby-commons/spec/unit/allure_spec.rb
@@ -93,8 +93,8 @@ describe Allure do
 
   context "with parameter helpers" do
     it "adds test parameter" do
-      allure.parameter("name", "value")
-      expect(@test_case.parameters.last).to eq(Allure::Parameter.new("name", "value"))
+      allure.parameter("name", "value", excluded: true, mode: "masked")
+      expect(@test_case.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: "masked"))
     end
   end
 
@@ -167,9 +167,9 @@ describe Allure do
 
     it "adds parameter" do
       allure.run_step("New step") do
-        allure.step_parameter("name", "value")
+        allure.step_parameter("name", "value", excluded: true, mode: "hidden")
       end
-      expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", "value"))
+      expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: "hidden"))
     end
   end
 

--- a/allure-ruby-commons/spec/unit/allure_spec.rb
+++ b/allure-ruby-commons/spec/unit/allure_spec.rb
@@ -167,9 +167,9 @@ describe Allure do
 
     it "adds parameter" do
       allure.run_step("New step") do
-        allure.step_parameter("name", "value", excluded: true, mode: "hidden")
+        allure.step_parameter("name", "value", excluded: true, mode: Allure::Parameter::HIDDEN)
       end
-      expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: "hidden"))
+      expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: Allure::Parameter::HIDDEN))
     end
 
     it "invalid parameter mode" do

--- a/allure-ruby-commons/spec/unit/allure_spec.rb
+++ b/allure-ruby-commons/spec/unit/allure_spec.rb
@@ -94,7 +94,8 @@ describe Allure do
   context "with parameter helpers" do
     it "adds test parameter" do
       allure.parameter("name", "value", excluded: true, mode: Allure::Parameter::MASKED)
-      expect(@test_case.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: Allure::Parameter::MASKED))
+      parameter = Allure::Parameter.new("name", "value", excluded: true, mode: Allure::Parameter::MASKED)
+      expect(@test_case.parameters.last).to eq(parameter)
     end
   end
 
@@ -169,7 +170,8 @@ describe Allure do
       allure.run_step("New step") do
         allure.step_parameter("name", "value", excluded: true, mode: Allure::Parameter::HIDDEN)
       end
-      expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: Allure::Parameter::HIDDEN))
+      parameter = Allure::Parameter.new("name", "value", excluded: true, mode: Allure::Parameter::HIDDEN)
+      expect(last_step.parameters.last).to eq(parameter)
     end
 
     it "uses default mode when invalid mode parameter is set" do

--- a/allure-ruby-commons/spec/unit/allure_spec.rb
+++ b/allure-ruby-commons/spec/unit/allure_spec.rb
@@ -173,10 +173,11 @@ describe Allure do
     end
 
     it "invalid parameter mode" do
-      msg = "Parameter mode 'jibberish' is invalid. Valid modes are: #{Allure::Parameter::MODES.join(', ')}"
+      modes = [Allure::Parameter::DEFAULT, Allure::Parameter::MASKED, Allure::Parameter::HIDDEN]
+      msg = "Parameter mode 'jiberish' is invalid. Valid modes are: #{modes.join(', ')}"
       expect(Allure.configuration.logger).to receive(:error).with(msg)
       allure.run_step("New step") do
-        allure.step_parameter("name", "value", excluded: true, mode: "jibberish")
+        allure.step_parameter("name", "value", excluded: true, mode: "jiberish")
       end
     end
   end

--- a/allure-ruby-commons/spec/unit/allure_spec.rb
+++ b/allure-ruby-commons/spec/unit/allure_spec.rb
@@ -171,6 +171,14 @@ describe Allure do
       end
       expect(last_step.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: "hidden"))
     end
+
+    it "invalid parameter mode" do
+      msg = "Parameter mode 'jibberish' is invalid. Valid modes are: #{Allure::Parameter::MODES.join(', ')}"
+      expect(Allure.configuration.logger).to receive(:error).with(msg)
+      allure.run_step("New step") do
+        allure.step_parameter("name", "value", excluded: true, mode: "jibberish")
+      end
+    end
   end
 
   context "with status details helpers" do

--- a/allure-ruby-commons/spec/unit/allure_spec.rb
+++ b/allure-ruby-commons/spec/unit/allure_spec.rb
@@ -93,8 +93,8 @@ describe Allure do
 
   context "with parameter helpers" do
     it "adds test parameter" do
-      allure.parameter("name", "value", excluded: true, mode: "masked")
-      expect(@test_case.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: "masked"))
+      allure.parameter("name", "value", excluded: true, mode: Allure::Parameter::MASKED)
+      expect(@test_case.parameters.last).to eq(Allure::Parameter.new("name", "value", excluded: true, mode: Allure::Parameter::MASKED))
     end
   end
 

--- a/allure-ruby-commons/spec/unit/test_result_spec.rb
+++ b/allure-ruby-commons/spec/unit/test_result_spec.rb
@@ -5,6 +5,7 @@ describe "AllureLifecycle::TestCaseResult" do
 
   let!(:result_container) { @result_container = start_test_container("Test Container") }
   let!(:test_case) { start_test_case(name: "Test Case", environment: environment) }
+  let(:environment) { "test" }
 
   context "without allure environment" do
     let(:environment) { nil }
@@ -44,6 +45,38 @@ describe "AllureLifecycle::TestCaseResult" do
         Allure::Label.new("host", Socket.gethostname),
         Allure::Label.new("language", "ruby")
       )
+    end
+  end
+
+  context "history id" do
+    it "History id is different for different non-excluded parameters" do
+      test_case1 = start_test_case(name: "Test Case", history_id: 1)
+      lifecycle.update_test_case do |test_case|
+        test_case.parameters.push(Allure::Parameter.new("name", "value1"))
+      end
+      test_case1.stop
+
+      test_case2 = start_test_case(name: "Test Case", history_id: 1)
+      lifecycle.update_test_case do |test_case|
+        test_case.parameters.push(Allure::Parameter.new("name", "value2"))
+      end
+      test_case2.stop
+      expect(test_case1.history_id).not_to eq(test_case2.history_id)
+    end
+
+    it "History id is the same for excluded parameters" do
+      test_case1 = start_test_case(name: "Test Case", history_id: 1)
+      lifecycle.update_test_case do |test_case|
+        test_case.parameters.push(Allure::Parameter.new("name", "value1", excluded: true))
+      end
+      test_case1.stop
+
+      test_case2 = start_test_case(name: "Test Case", history_id: 1)
+      lifecycle.update_test_case do |test_case|
+        test_case.parameters.push(Allure::Parameter.new("name", "value2", excluded: true))
+      end
+      test_case2.stop
+      expect(test_case1.history_id).to eq(test_case2.history_id)
     end
   end
 


### PR DESCRIPTION
Adding `excluded` and `mode` options for `Parameter` class for Ruby binding