### PR TITLE
Update allure-ruby-commons.gemspec

### DIFF
--- a/allure-ruby-commons/allure-ruby-commons.gemspec
+++ b/allure-ruby-commons/allure-ruby-commons.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "mime-types", ">= 3.3", "< 4"
   s.add_dependency "require_all", ">= 2", "< 4"
-  s.add_dependency "rspec-expectations", "~> 3.12"
+  s.add_dependency "rspec-expectations", "~> 3.13"
 end


### PR DESCRIPTION
bumps rspec-expectations version to 3.13